### PR TITLE
Fix CLI calls for heatmap generation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,6 +1,7 @@
 """cli.py – コマンドライン一括実行"""
 import argparse, shutil
 from pathlib import Path
+import pandas as pd
 from shift_suite import ingest_excel, build_heatmap, shortage_and_brief, summary
 from shift_suite.utils import safe_make_archive
 
@@ -9,6 +10,8 @@ def main():
     ap.add_argument("excel")
     ap.add_argument("out")
     ap.add_argument("--slot", type=int, default=30)
+    ap.add_argument("--header", type=int, default=3,
+                    help="Header row number of shift sheets (1-indexed)")
     ap.add_argument("--zip", action="store_true")
     args = ap.parse_args()
 
@@ -16,15 +19,33 @@ def main():
     out   = Path(args.out).expanduser()
     shutil.rmtree(out, ignore_errors=True)
 
-    long, wt = ingest_excel(
+    # Determine shift sheet names by excluding the master sheet
+    xls = pd.ExcelFile(excel)
+    shift_sheets = [s for s in xls.sheet_names if "勤務区分" not in s]
+
+    long, _ = ingest_excel(
         excel,
-        shift_sheets=None,  # Use all non-master sheets
-        master_sheet="勤務区分"  # Default master sheet name
+        shift_sheets=shift_sheets,
+        header_row=args.header,
     )
-    build_heatmap(long, wt, out, args.slot)
+
+    ref_start = pd.to_datetime(long["ds"]).dt.date.min()
+    ref_end = pd.to_datetime(long["ds"]).dt.date.max()
+
+    build_heatmap(
+        long,
+        out,
+        args.slot,
+        ref_start_date_for_need=ref_start,
+        ref_end_date_for_need=ref_end,
+        need_statistic_method="中央値",
+        need_remove_outliers=True,
+        need_iqr_multiplier=1.5,
+        min_method="p25",
+        max_method="p75",
+    )
     shortage_and_brief(out, args.slot)
-    summary_df = summary.daily_summary(out)
-    summary_df.to_csv(out / "summary.csv", index=False)
+    summary.build_staff_stats(long, out)
 
     if args.zip:
         safe_make_archive(out, out.with_suffix(".zip"))


### PR DESCRIPTION
## Summary
- update CLI to autodetect shift sheets and pass header row
- call `build_heatmap` with explicit keyword parameters
- run `shortage_and_brief` and generate staff stats instead of invalid daily summary

## Testing
- `pytest -q` *(fails: command not found)*
- `python cli.py -h` *(fails: ModuleNotFoundError: No module named 'pandas')*