### PR TITLE
Add additional analyzers and CLI support

### DIFF
--- a/shift_suite/tasks/__init__.py
+++ b/shift_suite/tasks/__init__.py
@@ -1,0 +1,15 @@
+from .analyzers import (
+    LeaveAnalyzer,
+    RestTimeAnalyzer,
+    WorkPatternAnalyzer,
+    AttendanceBehaviorAnalyzer,
+    CombinedScoreCalculator,
+)
+
+__all__ = [
+    "LeaveAnalyzer",
+    "RestTimeAnalyzer",
+    "WorkPatternAnalyzer",
+    "AttendanceBehaviorAnalyzer",
+    "CombinedScoreCalculator",
+]

--- a/shift_suite/tasks/analyzers/__init__.py
+++ b/shift_suite/tasks/analyzers/__init__.py
@@ -1,3 +1,13 @@
 from .leave import LeaveAnalyzer
+from .rest_time import RestTimeAnalyzer
+from .work_pattern import WorkPatternAnalyzer
+from .attendance_behavior import AttendanceBehaviorAnalyzer
+from .combined_score import CombinedScoreCalculator
 
-__all__ = ["LeaveAnalyzer"]
+__all__ = [
+    "LeaveAnalyzer",
+    "RestTimeAnalyzer",
+    "WorkPatternAnalyzer",
+    "AttendanceBehaviorAnalyzer",
+    "CombinedScoreCalculator",
+]

--- a/shift_suite/tasks/analyzers/attendance_behavior.py
+++ b/shift_suite/tasks/analyzers/attendance_behavior.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pandas as pd
+
+class AttendanceBehaviorAnalyzer:
+    """Simple attendance rate analysis based on working days."""
+
+    def analyze(self, df: pd.DataFrame) -> pd.DataFrame:
+        if df.empty or 'ds' not in df.columns:
+            return pd.DataFrame(columns=['staff', 'attendance_rate'])
+        df['date'] = pd.to_datetime(df['ds']).dt.date
+        daily = df.groupby(['staff', 'date'])['parsed_slots_count'].sum().reset_index()
+        daily['worked'] = daily['parsed_slots_count'] > 0
+        summary = daily.groupby('staff')['worked'].mean().reset_index(name='attendance_rate')
+        return summary

--- a/shift_suite/tasks/analyzers/combined_score.py
+++ b/shift_suite/tasks/analyzers/combined_score.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pandas as pd
+
+class CombinedScoreCalculator:
+    """Calculate a simple combined score from other analyses."""
+
+    def calculate(
+        self,
+        rest_df: pd.DataFrame,
+        work_df: pd.DataFrame,
+        attendance_df: pd.DataFrame,
+    ) -> pd.DataFrame:
+        if attendance_df.empty:
+            return pd.DataFrame()
+
+        avg_rest = (
+            rest_df.groupby('staff')['rest_hours'].mean().reset_index()
+            if not rest_df.empty else pd.DataFrame(columns=['staff', 'rest_hours'])
+        )
+
+        if not work_df.empty:
+            tmp = work_df.set_index('staff')
+            totals = tmp.sum(axis=1)
+            dominant = tmp.max(axis=1) / totals.replace(0, pd.NA)
+            pattern_df = dominant.reset_index(name='dominant_ratio')
+        else:
+            pattern_df = pd.DataFrame(columns=['staff', 'dominant_ratio'])
+
+        df = attendance_df.merge(avg_rest, on='staff', how='left').merge(pattern_df, on='staff', how='left')
+        df['rest_score'] = df['rest_hours'].fillna(0) / 24
+        df['pattern_score'] = 1 - df['dominant_ratio'].fillna(0)
+        df['final_score'] = 0.5 * df['attendance_rate'].fillna(0) + 0.25 * df['rest_score'] + 0.25 * df['pattern_score']
+        return df[['staff', 'final_score']]

--- a/shift_suite/tasks/analyzers/rest_time.py
+++ b/shift_suite/tasks/analyzers/rest_time.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import timedelta
+import pandas as pd
+
+class RestTimeAnalyzer:
+    """Analyze rest hours between consecutive working days for each staff."""
+
+    def analyze(self, df: pd.DataFrame, slot_minutes: int = 30) -> pd.DataFrame:
+        if df.empty or "ds" not in df.columns:
+            return pd.DataFrame(columns=["staff", "date", "rest_hours"])
+
+        work_df = df[df.get("parsed_slots_count", 0) > 0].copy()
+        if work_df.empty:
+            return pd.DataFrame(columns=["staff", "date", "rest_hours"])
+
+        work_df["date"] = pd.to_datetime(work_df["ds"]).dt.date
+        daily = (
+            work_df.groupby(["staff", "date"])["ds"]
+            .agg(["min", "max"])
+            .rename(columns={"min": "start", "max": "end"})
+            .reset_index()
+        )
+        daily["end"] = daily["end"] + pd.to_timedelta(slot_minutes, unit="m")
+        daily = daily.sort_values(["staff", "start"])
+        daily["rest_hours"] = (
+            daily.groupby("staff")["start"].shift(-1) - daily["end"]
+        ).dt.total_seconds() / 3600.0
+        return daily[["staff", "date", "rest_hours"]]

--- a/shift_suite/tasks/analyzers/work_pattern.py
+++ b/shift_suite/tasks/analyzers/work_pattern.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pandas as pd
+
+class WorkPatternAnalyzer:
+    """Analyse frequency of shift codes per staff."""
+
+    def analyze(self, df: pd.DataFrame) -> pd.DataFrame:
+        if df.empty or 'code' not in df.columns:
+            return pd.DataFrame()
+        work_df = df[df.get('parsed_slots_count', 0) > 0].copy()
+        if work_df.empty:
+            return pd.DataFrame()
+        counts = work_df.groupby(['staff', 'code']).size().unstack(fill_value=0)
+        counts = counts.reset_index()
+        counts.columns = [str(c) for c in counts.columns]
+        return counts

--- a/shift_suite/tasks/dashboard.py
+++ b/shift_suite/tasks/dashboard.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pandas as pd
+import plotly.express as px
+
+
+def employee_overview(score_df: pd.DataFrame):
+    """Return a bar chart of final scores per staff."""
+    if score_df is None or score_df.empty:
+        return px.bar(title="No data")
+    fig = px.bar(score_df, x="staff", y="final_score", title="Combined Score by Staff")
+    fig.update_layout(xaxis_title="Staff", yaxis_title="Score")
+    return fig
+
+
+def department_overview(score_df: pd.DataFrame, long_df: pd.DataFrame):
+    """Return a bar chart of average score per role."""
+    if score_df is None or score_df.empty or long_df is None or long_df.empty or "role" not in long_df.columns:
+        return px.bar(title="No data")
+    mapping = long_df[["staff", "role"]].drop_duplicates()
+    merged = mapping.merge(score_df, on="staff", how="left")
+    dept = merged.groupby("role")["final_score"].mean().reset_index()
+    fig = px.bar(dept, x="role", y="final_score", title="Average Score by Role")
+    fig.update_layout(xaxis_title="Role", yaxis_title="Score")
+    return fig


### PR DESCRIPTION
## Summary
- implement new analyzers (rest time, work pattern, attendance, combined score)
- expose analyzers from tasks package
- expand CLI bridge to run the new analyzers
- add minimal dashboard helpers
- begin wiring new options into the Streamlit app

## Testing
- `python -m py_compile $(git ls-files '*.py')`