### PR TITLE
Remove unused import

### DIFF
--- a/shift_suite/tasks/analyzers/rest_time.py
+++ b/shift_suite/tasks/analyzers/rest_time.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import timedelta
 import pandas as pd
 
 class RestTimeAnalyzer:


### PR DESCRIPTION
## Summary
- clean up `rest_time.py` by removing unused timedelta import

## Testing
- `python -m pytest` *(fails: No module named pytest)*