### PR TITLE
Check parsed_slots_count before attendance analysis

### DIFF
--- a/shift_suite/tasks/analyzers/attendance_behavior.py
+++ b/shift_suite/tasks/analyzers/attendance_behavior.py
@@ -6,10 +6,32 @@ class AttendanceBehaviorAnalyzer:
     """Simple attendance rate analysis based on working days."""
 
     def analyze(self, df: pd.DataFrame) -> pd.DataFrame:
-        if df.empty or 'ds' not in df.columns:
-            return pd.DataFrame(columns=['staff', 'attendance_rate'])
-        df['date'] = pd.to_datetime(df['ds']).dt.date
-        daily = df.groupby(['staff', 'date'])['parsed_slots_count'].sum().reset_index()
-        daily['worked'] = daily['parsed_slots_count'] > 0
-        summary = daily.groupby('staff')['worked'].mean().reset_index(name='attendance_rate')
+        """Calculate attendance rate for each staff.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Input data containing ``ds``, ``staff`` and ``parsed_slots_count`` columns.
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame with ``staff`` and ``attendance_rate`` columns.
+        """
+        if (
+            df.empty
+            or "ds" not in df.columns
+            or "parsed_slots_count" not in df.columns
+        ):
+            return pd.DataFrame(columns=["staff", "attendance_rate"])
+        df["date"] = pd.to_datetime(df["ds"]).dt.date
+        daily = (
+            df.groupby(["staff", "date"])["parsed_slots_count"]
+            .sum()
+            .reset_index()
+        )
+        daily["worked"] = daily["parsed_slots_count"] > 0
+        summary = (
+            daily.groupby("staff")["worked"].mean().reset_index(name="attendance_rate")
+        )
         return summary


### PR DESCRIPTION
## Summary
- handle missing `parsed_slots_count` gracefully in `AttendanceBehaviorAnalyzer`
- document required input columns for attendance analysis

## Testing
- `ruff check shift_suite/tasks/analyzers/attendance_behavior.py`
- `pytest -q` *(fails: command not found)*