### PR TITLE
Add monthly outputs for rest time and work patterns

### DIFF
--- a/app.py
+++ b/app.py
@@ -237,7 +237,9 @@ if "app_initialized" not in st.session_state:
     st.session_state.leave_analysis_results = {}
     
     st.session_state.rest_time_results = None
+    st.session_state.rest_time_monthly = None
     st.session_state.work_pattern_results = None
+    st.session_state.work_pattern_monthly = None
     st.session_state.attendance_results = None
     st.session_state.combined_score_results = None
     log.info("セッションステートを初期化しました。")
@@ -634,11 +636,19 @@ if run_button_clicked:
                     elif opt_module_name_exec_run == "Fairness": 
                         run_fairness(long_df, out_dir_exec)
                     elif opt_module_name_exec_run == "Rest Time Analysis":
-                        st.session_state.rest_time_results = RestTimeAnalyzer().analyze(long_df)
+                        rta = RestTimeAnalyzer()
+                        st.session_state.rest_time_results = rta.analyze(long_df)
                         st.session_state.rest_time_results.to_csv(out_dir_exec / "rest_time.csv", index=False)
+                        st.session_state.rest_time_monthly = rta.monthly(st.session_state.rest_time_results)
+                        if st.session_state.rest_time_monthly is not None:
+                            st.session_state.rest_time_monthly.to_csv(out_dir_exec / "rest_time_monthly.csv", index=False)
                     elif opt_module_name_exec_run == "Work Pattern Analysis":
-                        st.session_state.work_pattern_results = WorkPatternAnalyzer().analyze(long_df)
+                        wpa = WorkPatternAnalyzer()
+                        st.session_state.work_pattern_results = wpa.analyze(long_df)
                         st.session_state.work_pattern_results.to_csv(out_dir_exec / "work_patterns.csv", index=False)
+                        st.session_state.work_pattern_monthly = wpa.analyze_monthly(long_df)
+                        if st.session_state.work_pattern_monthly is not None:
+                            st.session_state.work_pattern_monthly.to_csv(out_dir_exec / "work_pattern_monthly.csv", index=False)
                     elif opt_module_name_exec_run == "Attendance Analysis":
                         st.session_state.attendance_results = AttendanceBehaviorAnalyzer().analyze(long_df)
                         st.session_state.attendance_results.to_csv(out_dir_exec / "attendance.csv", index=False)

--- a/shift_suite/tasks/analyzers/rest_time.py
+++ b/shift_suite/tasks/analyzers/rest_time.py
@@ -29,3 +29,16 @@ class RestTimeAnalyzer:
             daily.groupby("staff")["start"].shift(-1) - daily["end"]
         ).dt.total_seconds() / 3600.0
         return daily[["staff", "date", "rest_hours"]]
+
+    def monthly(self, daily_df: pd.DataFrame) -> pd.DataFrame:
+        """Aggregate daily rest time DataFrame to monthly averages."""
+        if daily_df.empty or not {"staff", "date", "rest_hours"}.issubset(daily_df.columns):
+            return pd.DataFrame()
+
+        df = daily_df.copy()
+        df["month"] = pd.to_datetime(df["date"]).dt.to_period("M")
+        monthly = (
+            df.groupby(["staff", "month"])["rest_hours"].mean().reset_index()
+        )
+        monthly["month"] = monthly["month"].astype(str)
+        return monthly

--- a/shift_suite/tasks/analyzers/work_pattern.py
+++ b/shift_suite/tasks/analyzers/work_pattern.py
@@ -25,3 +25,24 @@ class WorkPatternAnalyzer:
         df_out = pd.concat([counts, ratios], axis=1).reset_index()
         df_out.columns = [str(c) for c in df_out.columns]
         return df_out
+
+    def analyze_monthly(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Analyse shift patterns per staff for each month."""
+        if df.empty or "code" not in df.columns or "ds" not in df.columns:
+            return pd.DataFrame()
+
+        work_df = df[df.get("parsed_slots_count", 0) > 0].copy()
+        if work_df.empty:
+            return pd.DataFrame()
+
+        work_df["month"] = pd.to_datetime(work_df["ds"]).dt.to_period("M")
+        counts = work_df.groupby(["staff", "month", "code"]).size().unstack(fill_value=0)
+
+        totals = counts.sum(axis=1)
+        ratios = counts.div(totals.replace(0, pd.NA), axis=0).fillna(0)
+        ratios = ratios.add_suffix("_ratio")
+
+        df_out = pd.concat([counts, ratios], axis=1).reset_index()
+        df_out.columns = [str(c) for c in df_out.columns]
+        df_out["month"] = df_out["month"].astype(str)
+        return df_out

--- a/shift_suite/tasks/cli_bridge.py
+++ b/shift_suite/tasks/cli_bridge.py
@@ -45,20 +45,36 @@ def main(argv: list[str] | None = None) -> list[Path]:
         results.append(fp)
 
     if args.analysis in ("rest", "score", "all"):
-        rest_res = RestTimeAnalyzer().analyze(df)
+        rta = RestTimeAnalyzer()
+        rest_res = rta.analyze(df)
         fp = out_dir / "rest_time.csv"
         rest_res.to_csv(fp, index=False)
         print(f"Results saved to {fp}")
         results.append(fp)
+
+        monthly_rest = rta.monthly(rest_res)
+        if not monthly_rest.empty:
+            fp_m = out_dir / "rest_time_monthly.csv"
+            monthly_rest.to_csv(fp_m, index=False)
+            print(f"Results saved to {fp_m}")
+            results.append(fp_m)
     else:
         rest_res = None
 
     if args.analysis in ("work", "score", "all"):
-        work_res = WorkPatternAnalyzer().analyze(df)
+        wpa = WorkPatternAnalyzer()
+        work_res = wpa.analyze(df)
         fp = out_dir / "work_patterns.csv"
         work_res.to_csv(fp, index=False)
         print(f"Results saved to {fp}")
         results.append(fp)
+
+        monthly_work = wpa.analyze_monthly(df)
+        if not monthly_work.empty:
+            fp_m = out_dir / "work_pattern_monthly.csv"
+            monthly_work.to_csv(fp_m, index=False)
+            print(f"Results saved to {fp_m}")
+            results.append(fp_m)
     else:
         work_res = None
 


### PR DESCRIPTION
## Summary
- compute monthly summaries in analyzers
- output monthly CSVs in `cli_bridge.py`
- save monthly results from the GUI app

## Testing
- `python -m py_compile app.py shift_suite/tasks/analyzers/rest_time.py shift_suite/tasks/analyzers/work_pattern.py shift_suite/tasks/cli_bridge.py`