### PR TITLE
Fix Python version docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ are automatically imported by `shift_suite/__init__.py`, so you can simply
 
 ## Usage
 
-1. Install dependencies (requires Python 3.12):
+1. Install dependencies (requires Python 3.12 or later):
 
    ```bash
    pip install -r requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "shift-suite"
 version = "0.9.0"
 description = "Excel シフト表を解析・可視化するツール"
 authors = [{name = "Shinya Fujimaki", email = "fuji1006@example.com"}]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 
 # ── 実行に必要な外部ライブラリ ──
 dependencies = [

--- a/shift_suite.egg-info/PKG-INFO
+++ b/shift_suite.egg-info/PKG-INFO
@@ -3,7 +3,7 @@ Name: shift-suite
 Version: 0.9.0
 Summary: Excel シフト表を解析・可視化するツール
 Author-email: Shinya Fujimaki <fuji1006@example.com>
-Requires-Python: >=3.10
+Requires-Python: >=3.12
 Requires-Dist: pandas>=2.2
 Requires-Dist: numpy>=1.26
 Requires-Dist: plotly>=5.20


### PR DESCRIPTION
## Summary
- require Python 3.12+ in `pyproject.toml`
- note Python 3.12+ in the README
- update egg metadata to match

## Testing
- `pytest -q`
- `ruff check .` *(fails: F401 unused imports in app.py)*