### PR TITLE
Add holiday parameter & vectorize shortage

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -14,10 +14,26 @@ def main():
     ap.add_argument("--header", type=int, default=3,
                     help="Header row number of shift sheets (1-indexed)")
     ap.add_argument("--zip", action="store_true")
+    ap.add_argument("--holidays", help="Optional holiday CSV or JSON file")
     args = ap.parse_args()
 
     excel = Path(args.excel).expanduser()
     out   = Path(args.out).expanduser()
+    holiday_dates = None
+    if args.holidays:
+        fp_h = Path(args.holidays).expanduser()
+        try:
+            if fp_h.suffix.lower() == ".json":
+                import json
+                with open(fp_h, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                if isinstance(data, list):
+                    holiday_dates = [pd.to_datetime(d).date() for d in data]
+            else:
+                df_h = pd.read_csv(fp_h, header=None)
+                holiday_dates = [pd.to_datetime(x).date() for x in df_h.iloc[:,0].dropna().unique()]
+        except Exception as e:
+            print(f"Failed to read holidays from {fp_h}: {e}")
     shutil.rmtree(out, ignore_errors=True)
 
     # Determine shift sheet names by excluding the master sheet
@@ -45,7 +61,7 @@ def main():
         min_method="p25",
         max_method="p75",
     )
-    shortage_and_brief(out, args.slot)
+    shortage_and_brief(out, args.slot, holidays=holiday_dates)
     try:
         build_hire_plan_from_shortage(out)
     except Exception as e:


### PR DESCRIPTION
## Summary
- add optional `holidays` parameter to `shortage_and_brief`
- speed up calculations by vectorizing holiday-aware need subtraction
- allow CLI to accept CSV/JSON holiday list
- update GUI with holiday file uploader

## Testing
- `python -m py_compile cli.py app.py shift_suite/tasks/shortage.py`
- `ruff check .`