### PR TITLE
Unify header default

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,13 @@ are automatically imported by `shift_suite/__init__.py`, so you can simply
 3. To use the CLI, run:
 
    ```bash
-   python cli.py <excel.xlsx> <out_dir> [--slot MIN] [--zip]
+   python cli.py <excel.xlsx> <out_dir> [--slot MIN] [--header ROW] [--zip]
    ```
 
    - `<excel.xlsx>`: path to the source Excel file
    - `<out_dir>`: directory where results will be written
    - `--slot`: time slot length in minutes (default: 30)
+   - `--header`: header row number in the shift sheets (default: 2)
    - `--zip`: optionally compress the output directory
 
 4. Run analyses directly on a CSV file using the module entry point:

--- a/cli.py
+++ b/cli.py
@@ -11,8 +11,12 @@ def main():
     ap.add_argument("excel")
     ap.add_argument("out")
     ap.add_argument("--slot", type=int, default=30)
-    ap.add_argument("--header", type=int, default=3,
-                    help="Header row number of shift sheets (1-indexed)")
+    ap.add_argument(
+        "--header",
+        type=int,
+        default=2,
+        help="Header row number of shift sheets (1-indexed)",
+    )
     ap.add_argument("--zip", action="store_true")
     args = ap.parse_args()
 


### PR DESCRIPTION
## Summary
- use one `--header` default across CLI and `ingest_excel`
- document `--header` option in README

## Testing
- `python -m py_compile cli.py shift_suite/tasks/io_excel.py app.py`