### PR TITLE
Add cost-benefit analysis to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,13 @@ After `shortage_role.xlsx` is generated, the application now calls
 `h2hire.build_hire_plan` to convert shortage hours into required FTE counts.
 The resulting `hire_plan.xlsx` is stored in the same output folder and the
 **Shortage** tab displays these FTE numbers per role.
+
+The CLI additionally runs a cost/benefit simulation once the hire plan has
+been created. `analyze_cost_benefit(out_dir)` writes `cost_benefit.xlsx`
+to the same folder. You can customise the calculation with optional
+parameters:
+
+- `wage_direct` – hourly cost of direct employees (default `1500`)
+- `wage_temp` – hourly cost for temporary staff (default `2200`)
+- `hiring_cost_once` – one‑time cost per hire (default `180000`)
+- `penalty_per_lack_h` – penalty per uncovered hour (default `4000`)

--- a/cli.py
+++ b/cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pandas as pd
 from shift_suite import ingest_excel, build_heatmap, shortage_and_brief, summary
 from shift_suite.h2hire import build_hire_plan as build_hire_plan_from_shortage
+from shift_suite.tasks.cost_benefit import analyze_cost_benefit
 from shift_suite.utils import safe_make_archive
 
 def main():
@@ -70,6 +71,11 @@ def main():
         build_hire_plan_from_shortage(out)
     except Exception as e:
         print(f"hire_plan generation failed: {e}")
+    else:
+        try:
+            analyze_cost_benefit(out)
+        except Exception as e:
+            print(f"cost-benefit analysis failed: {e}")
     summary.build_staff_stats(long, out)
 
     if args.zip:


### PR DESCRIPTION
## Summary
- call `analyze_cost_benefit` after building hire plan in `cli.py`
- document the new automatic step and its parameters in README

## Testing
- `python -m py_compile cli.py shift_suite/tasks/cost_benefit.py`