### PR TITLE
Localize dashboard chart labels

### DIFF
--- a/shift_suite/tasks/dashboard.py
+++ b/shift_suite/tasks/dashboard.py
@@ -3,13 +3,34 @@ from __future__ import annotations
 import pandas as pd
 import plotly.express as px
 
+JP = {
+    "Staff": "スタッフ",
+    "Score": "スコア",
+    "Role": "職種",
+    "Month": "月",
+    "Shortage Hours": "不足時間(h)",
+    "Total Leave Days": "総休暇日数",
+    "Shift Code": "勤務区分",
+    "Ratio": "比率",
+}
+
+
+def _(text: str) -> str:
+    return JP.get(text, text)
+
 
 def employee_overview(score_df: pd.DataFrame):
     """Return a bar chart of final scores per staff."""
     if score_df is None or score_df.empty:
         return px.bar(title="No data")
-    fig = px.bar(score_df, x="staff", y="final_score", title="Combined Score by Staff")
-    fig.update_layout(xaxis_title="Staff", yaxis_title="Score")
+    fig = px.bar(
+        score_df,
+        x="staff",
+        y="final_score",
+        title="Combined Score by Staff",
+        labels={"staff": _("Staff"), "final_score": _("Score")},
+    )
+    fig.update_layout(xaxis_title=_("Staff"), yaxis_title=_("Score"))
     return fig
 
 
@@ -20,8 +41,14 @@ def department_overview(score_df: pd.DataFrame, long_df: pd.DataFrame):
     mapping = long_df[["staff", "role"]].drop_duplicates()
     merged = mapping.merge(score_df, on="staff", how="left")
     dept = merged.groupby("role")["final_score"].mean().reset_index()
-    fig = px.bar(dept, x="role", y="final_score", title="Average Score by Role")
-    fig.update_layout(xaxis_title="Role", yaxis_title="Score")
+    fig = px.bar(
+        dept,
+        x="role",
+        y="final_score",
+        title="Average Score by Role",
+        labels={"role": _("Role"), "final_score": _("Score")},
+    )
+    fig.update_layout(xaxis_title=_("Role"), yaxis_title=_("Score"))
     return fig
 
 
@@ -43,6 +70,6 @@ def work_pattern_heatmap(df: pd.DataFrame):
         zmin=0,
         zmax=1,
         color_continuous_scale="Blues",
-        labels={"x": "Shift Code", "y": "Staff", "color": "Ratio"},
+        labels={"x": _("Shift Code"), "y": _("Staff"), "color": _("Ratio")},
     )
     return fig

--- a/shift_suite/tasks/ppt.py
+++ b/shift_suite/tasks/ppt.py
@@ -9,6 +9,21 @@ import pandas as pd
 from pptx import Presentation
 from pptx.util import Inches
 
+JP = {
+    "Staff": "スタッフ",
+    "Score": "スコア",
+    "Role": "職種",
+    "Month": "月",
+    "Shortage Hours": "不足時間(h)",
+    "Total Leave Days": "総休暇日数",
+    "Shortage by Role": "職種別不足",
+    "Cost Benefit Scenarios": "コスト便益シナリオ",
+}
+
+
+def _(text: str) -> str:
+    return JP.get(text, text)
+
 log = logging.getLogger(__name__)
 
 
@@ -22,15 +37,15 @@ def _add_shortage_slide(prs: Presentation, shortage_fp: Path) -> None:
 
     fig, ax = plt.subplots(figsize=(6, 4))
     df.plot.bar(x="role", y="lack_h", ax=ax)
-    ax.set_title("Shortage by Role")
-    ax.set_ylabel("Lack Hours")
+    ax.set_title(_("Shortage by Role"))
+    ax.set_ylabel(_("Shortage Hours"))
     plt.tight_layout()
 
     with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_png:
         fig.savefig(tmp_png.name)
         plt.close(fig)
         slide = prs.slides.add_slide(prs.slide_layouts[5])
-        slide.shapes.title.text = "Shortage by Role"
+        slide.shapes.title.text = _("Shortage by Role")
         slide.shapes.add_picture(tmp_png.name, Inches(1), Inches(1), width=Inches(8))
     Path(tmp_png.name).unlink(missing_ok=True)
 
@@ -48,14 +63,14 @@ def _add_cost_slide(prs: Presentation, cost_fp: Path) -> None:
     fig, ax = plt.subplots(figsize=(6, 4))
     df[cost_col].plot.bar(ax=ax)
     ax.set_ylabel(cost_col)
-    ax.set_title("Cost Benefit Scenarios")
+    ax.set_title(_("Cost Benefit Scenarios"))
     plt.tight_layout()
 
     with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_png:
         fig.savefig(tmp_png.name)
         plt.close(fig)
         slide = prs.slides.add_slide(prs.slide_layouts[5])
-        slide.shapes.title.text = "Cost Benefit"
+        slide.shapes.title.text = _("Cost Benefit Scenarios")
         slide.shapes.add_picture(tmp_png.name, Inches(1), Inches(1), width=Inches(8))
     Path(tmp_png.name).unlink(missing_ok=True)
 


### PR DESCRIPTION
## Summary
- add JP translations for chart axis labels
- localize shortage tab charts
- update leave analysis charts with axis labels
- apply same translations in dashboard and ppt helpers

## Testing
- `pytest -q`
- `ruff check` *(fails: Found 180 errors)*