### PR TITLE
Support multiple holiday calendars

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,15 @@ are automatically imported by `shift_suite/__init__.py`, so you can simply
    ```
 
    Follow the on-screen instructions to upload your shift spreadsheet and
-   execute the desired analyses.
+   execute the desired analyses. Separate upload fields are provided for
+   global and local holiday calendars if you wish to factor them into the
+   shortage analysis and forecasts.
 
 3. To use the CLI, run:
 
    ```bash
-   python cli.py <excel.xlsx> <out_dir> [--slot MIN] [--header ROW] [--zip] [--holidays FILE]
+   python cli.py <excel.xlsx> <out_dir> [--slot MIN] [--header ROW] [--zip] \
+       [--holidays-global FILE] [--holidays-local FILE]
    ```
 
    - `<excel.xlsx>`: path to the source Excel file
@@ -73,7 +76,8 @@ are automatically imported by `shift_suite/__init__.py`, so you can simply
    - `--slot`: time slot length in minutes (default: 30)
    - `--header`: header row number in the shift sheets (default: 2)
    - `--zip`: optionally compress the output directory
-   - `--holidays`: optional CSV or JSON file listing holiday dates
+   - `--holidays-global`: CSV/JSON with nationally observed holidays
+   - `--holidays-local`: CSV/JSON with site-specific holidays
 
 4. Run analyses directly on a CSV file using the module entry point:
 

--- a/shift_suite/tasks/shortage.py
+++ b/shift_suite/tasks/shortage.py
@@ -23,13 +23,33 @@ def shortage_and_brief(
     out_dir: Path | str,
     slot: int,
     *,
+    holidays_global: Iterable[dt.date] | None = None,
+    holidays_local: Iterable[dt.date] | None = None,
     holidays: Iterable[dt.date] | None = None,
 ) -> Tuple[Path, Path] | None:
+    """Run shortage analysis and KPI summary.
+
+    Parameters
+    ----------
+    out_dir:
+        Output directory containing heatmap files.
+    slot:
+        Slot size in minutes.
+    holidays_global:
+        Dates for globally observed holidays.
+    holidays_local:
+        Additional local or facility specific holidays.
+    holidays:
+        Legacy single holiday list; combined with the above.
+    """
     out_dir_path = Path(out_dir)
     time_labels = gen_labels(slot)
     slot_hours = slot / 60.0
 
-    estimated_holidays_set: Set[dt.date] = set(holidays or [])
+    estimated_holidays_set: Set[dt.date] = set()
+    for src in (holidays_global, holidays_local, holidays):
+        if src:
+            estimated_holidays_set.update(src)
     heatmap_meta_path = out_dir_path / "heatmap.meta.json"
     try:
         with open(heatmap_meta_path, 'r', encoding='utf-8') as f:


### PR DESCRIPTION
## Summary
- extend `shortage_and_brief` to handle `holidays_global` and `holidays_local`
- parse the new options in the CLI and GUI
- document usage of multiple holiday calendars

## Testing
- `pytest -q`