### PR TITLE
Add shortage-leave merge and dashboard display

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,9 @@ parameters:
 - `wage_temp` – hourly cost for temporary staff (default `2200`)
 - `hiring_cost_once` – one‑time cost per hire (default `180000`)
 - `penalty_per_lack_h` – penalty per uncovered hour (default `4000`)
+
+If a `leave_analysis.csv` is also present in the output folder you can call
+`merge_shortage_leave(out_dir)` to create `shortage_leave.xlsx`. This file
+combines the per-slot shortage counts with daily leave applicants and adds a
+`net_shortage` column. The Streamlit dashboard automatically visualises this
+table under the **Shortage** tab.

--- a/app.py
+++ b/app.py
@@ -159,6 +159,8 @@ JP = {
     "Shortage by Role (hours)": "職種別不足時間 (h)",
     "Shortage by Time (count per day)": "時間帯別不足人数 (日別)",
     "Shortage Frequency (days)": "不足発生頻度 (日数)",
+    "Shortage with Leave": "不足と休暇数",
+    "Net Shortage": "差引不足",
     "Select date to display": "表示する日付を選択",
     "No date columns in shortage data.": "不足時間データに日付列がありません。",
     "Display all time-slot shortage data": "全時間帯別不足データ表示",
@@ -1116,6 +1118,24 @@ def display_shortage_tab(tab_container, data_dir):
                 st.error(f"shortage_freq.xlsx 表示エラー: {e}")
         else:
             st.info(_("Shortage") + " (shortage_freq.xlsx) " + _("が見つかりません。"))
+
+        fp_s_leave = data_dir / "shortage_leave.xlsx"
+        if fp_s_leave.exists():
+            try:
+                df_sl = pd.read_excel(fp_s_leave)
+                st.write(_("Shortage with Leave"))
+                display_sl = df_sl.rename(columns={
+                    "time": _("Time"),
+                    "date": _("Date"),
+                    "lack": _("Shortage Hours"),
+                    "leave_applicants": _("Total Leave Days"),
+                    "net_shortage": _("Net Shortage"),
+                })
+                st.dataframe(display_sl, use_container_width=True, hide_index=True)
+            except Exception as e:
+                st.error(f"shortage_leave.xlsx 表示エラー: {e}")
+        else:
+            st.info(_("Shortage") + " (shortage_leave.xlsx) " + _("が見つかりません。"))
 
         fp_cost = data_dir / "cost_benefit.xlsx"
         if fp_cost.exists():

--- a/shift_suite/__init__.py
+++ b/shift_suite/__init__.py
@@ -24,6 +24,7 @@ to_hhmm             = utils.to_hhmm
 ingest_excel        = sys.modules["shift_suite.io_excel"].ingest_excel
 build_heatmap       = sys.modules["shift_suite.heatmap"].build_heatmap
 shortage_and_brief  = sys.modules["shift_suite.shortage"].shortage_and_brief
+merge_shortage_leave = sys.modules["shift_suite.shortage"].merge_shortage_leave
 # build_stats関数のインポート
 build_stats         = sys.modules["shift_suite.tasks.build_stats"].build_stats
 detect_anomaly      = sys.modules["shift_suite.anomaly"].detect_anomaly


### PR DESCRIPTION
## Summary
- implement `merge_shortage_leave` to merge daily leave counts with time-slot shortage data
- expose the helper via package init
- display `shortage_leave.xlsx` on the Streamlit dashboard
- document the new file in the README

## Testing
- `pytest -q`