### PR TITLE
Fix ARIMA training series lookup

### DIFF
--- a/shift_suite/tasks/forecast.py
+++ b/shift_suite/tasks/forecast.py
@@ -309,9 +309,13 @@ def forecast_need(
             if "holiday" in exog_cols:
                 future_exog["holiday"] = [1 if d.date() in holiday_set else 0 for d in future_dates]
         arima_fc = arima_mod.predict(n_periods=periods, exogenous=future_exog)
-        denom_a = np.where(arima_mod.y != 0, arima_mod.y, np.nan)
+        try:
+            train_y = getattr(arima_mod, "y", arima_mod.arima_res_.data.endog)
+        except Exception:
+            train_y = df["y"].to_numpy()
+        denom_a = np.where(train_y != 0, train_y, np.nan)
         arima_mape = np.nanmean(
-            np.abs((arima_mod.y - arima_mod.predict_in_sample()) / denom_a)
+            np.abs((train_y - arima_mod.predict_in_sample()) / denom_a)
         )
     elif choose in ("auto", "arima"):
         log.warning("[forecast] ARIMA 指定ですが pmdarima が無いため ETS を使用")

--- a/tests/test_forecast_need.py
+++ b/tests/test_forecast_need.py
@@ -1,0 +1,43 @@
+import types
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from shift_suite.tasks import forecast
+from shift_suite.tasks.forecast import forecast_need
+
+class FakeARIMA:
+    def __init__(self, y):
+        self.arima_res_ = types.SimpleNamespace(
+            data=types.SimpleNamespace(endog=np.asarray(y))
+        )
+        # intentionally no 'y' attribute
+
+    def predict(self, n_periods, exogenous=None):
+        return np.repeat(self.arima_res_.data.endog[-1], n_periods)
+
+    def predict_in_sample(self):
+        return self.arima_res_.data.endog
+
+
+def fake_auto_arima(y, **kwargs):
+    return FakeARIMA(y)
+
+
+def test_forecast_need_arima_without_y(tmp_path, monkeypatch):
+    df = pd.DataFrame({
+        "ds": pd.date_range("2024-01-01", periods=5),
+        "y": [1, 2, 3, 4, 5],
+    })
+    demand_fp = tmp_path / "demand.csv"
+    df.to_csv(demand_fp, index=False)
+
+    excel_fp = tmp_path / "out.xlsx"
+
+    monkeypatch.setattr(forecast, "_HAS_PMDARIMA", True)
+    monkeypatch.setattr(forecast, "pm", types.SimpleNamespace(auto_arima=fake_auto_arima))
+
+    out = forecast_need(demand_fp, excel_fp, choose="arima", periods=3)
+    assert out.exists()
+    result = pd.read_excel(out)
+    assert len(result) == 3
+


### PR DESCRIPTION
## Summary
- handle missing `y` attribute when computing MAPE for ARIMA
- test `forecast_need` with a mocked ARIMA object lacking `y`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*