### PR TITLE
Handle longer forecast shortage

### DIFF
--- a/shift_suite/tasks/rl.py
+++ b/shift_suite/tasks/rl.py
@@ -103,6 +103,11 @@ def learn_roster(
         if col:
             shortage_hist = df_sh[col].values.astype(float)[: len(demand)]
 
+    if len(shortage_hist) < len(forecast):
+        # Padding prevents index errors when the forecast extends beyond
+        # the available shortage history.
+        shortage_hist = np.pad(shortage_hist, (0, len(forecast) - len(shortage_hist)), constant_values=0)
+
     if len(demand) < 2 or demand.sum() == 0:
         log.warning("[rl] 需要データが不足しているため学習をスキップ")
         return None

--- a/tests/test_rl.py
+++ b/tests/test_rl.py
@@ -1,0 +1,35 @@
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from shift_suite.tasks import rl
+
+class DummyPPO:
+    def __init__(self, *args, **kwargs):
+        self.env = args[1]
+    def learn(self, *args, **kwargs):
+        pass
+    def predict(self, obs, deterministic=True):
+        return np.array([0]), None
+    def save(self, path):
+        pass
+    @classmethod
+    def load(cls, path):
+        return cls(None, rl.RosterEnv(np.array([0])))
+
+def test_learn_roster_forecast_longer(monkeypatch, tmp_path):
+    demand_df = pd.DataFrame({"ds": pd.date_range("2024-01-01", periods=2), "need": [1,2]})
+    demand_fp = tmp_path / "demand.csv"
+    demand_df.to_csv(demand_fp, index=False)
+
+    fc_df = pd.DataFrame({"yhat": [1,2,3,4]})
+    fc_fp = tmp_path / "fc.csv"
+    fc_df.to_csv(fc_fp, index=False)
+
+    sh_df = pd.DataFrame({"shortage": [0]})
+    sh_fp = tmp_path / "sh.csv"
+    sh_df.to_csv(sh_fp, index=False)
+
+    monkeypatch.setattr(rl, "PPO", DummyPPO)
+
+    out = rl.learn_roster(demand_fp, tmp_path / "out.xlsx", forecast_csv=fc_fp, shortage_csv=sh_fp)
+    assert out is not None


### PR DESCRIPTION
## Summary
- pad shortage history to length of forecast in RL roster generation
- add unit test for roster learning with longer forecast

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*