### PR TITLE
Allow multi-day leave selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,10 @@ concentration threshold. Hovering over the points reveals the staff names who
 requested leave. A second chart plots the share of requesting staff
 (`leave_applicants_count ÷ total_staff`) for those days.
 
-You can click or lasso points on this chart to select specific dates. The
-selected staff members are listed below, together with a bar chart showing how
-frequently each person appears within the chosen dates.
+You can click or lasso points on this chart to select specific dates. Multiple
+dates accumulate across clicks, and the selected staff members are listed below,
+together with a bar chart showing how frequently each person appears within the
+chosen range. Use the **選択をクリア** button to reset the selection.
 
 ### Shortage → Hire plan workflow
 


### PR DESCRIPTION
## Summary
- keep selected leave dates in Streamlit session state
- document multi-click selection in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas and numpy)*