### PR TITLE
Handle PPO load failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ generation uses `python-pptx`, which is optional.  Install these via
 `pip install -r requirements.txt` before running `app.py` or the CLIs if you
 need the related features.
 
+### Reinforcement learning
+
+`learn_roster` optionally loads a saved PPO model. If the model cannot
+be deserialised, an error is logged and the function returns `None`
+instead of raising an exception.
+
 ### Example output
 
 Running the bridge command on a CSV with `staff`, `ds` (timestamp) and

--- a/shift_suite/tasks/rl.py
+++ b/shift_suite/tasks/rl.py
@@ -118,7 +118,11 @@ def learn_roster(
     # --- モデル学習 or 読み込み -----------------------
     env = RosterEnv(demand, shortage_hist)
     if use_saved_model and model_path and Path(model_path).exists():
-        model = PPO.load(model_path)
+        try:
+            model = PPO.load(model_path)
+        except Exception as e:  # pragma: no cover - just in case
+            log.error(f"[rl] model load failed: {e}", exc_info=True)
+            return None
     else:
         model = PPO("MlpPolicy", env, verbose=0)
         model.learn(total_timesteps=len(demand) * horizon)

--- a/tests/test_learn_roster.py
+++ b/tests/test_learn_roster.py
@@ -63,3 +63,68 @@ def test_learn_roster_generates_excel(tmp_path, monkeypatch):
     assert out.exists()
     roster_df = pd.read_excel(out)
     assert len(roster_df) == horizon
+
+
+def test_learn_roster_model_load_failure(tmp_path, monkeypatch):
+    fake_gym = types.SimpleNamespace()
+
+    class FakeEnv:
+        def reset(self, *args, **kwargs):
+            return None
+
+    fake_gym.Env = FakeEnv
+    fake_gym.spaces = types.SimpleNamespace(
+        Discrete=lambda *a, **kw: None,
+        Box=lambda *a, **kw: None,
+    )
+    monkeypatch.setitem(sys.modules, "gymnasium", fake_gym)
+
+    class FakePPO:
+        def __init__(self, policy, env, verbose=0):
+            self.env = env
+
+        def learn(self, total_timesteps):
+            pass
+
+        def predict(self, obs, deterministic=True):
+            return np.array([1]), None
+
+        @classmethod
+        def load(cls, path):
+            raise RuntimeError("load failed")
+
+        def save(self, path):
+            pass
+
+    fake_sb3 = types.SimpleNamespace(PPO=FakePPO)
+    monkeypatch.setitem(sys.modules, "stable_baselines3", fake_sb3)
+
+    from shift_suite.tasks.rl import learn_roster
+
+    demand_df = pd.DataFrame({
+        "ds": pd.date_range("2024-01-01", periods=2),
+        "need": [1, 2],
+    })
+    demand_csv = tmp_path / "demand.csv"
+    demand_df.to_csv(demand_csv, index=False)
+
+    forecast_df = pd.DataFrame({
+        "ds": pd.date_range("2024-01-03", periods=3),
+        "forecast": [2] * 3,
+    })
+    forecast_csv = tmp_path / "forecast.csv"
+    forecast_df.to_csv(forecast_csv, index=False)
+
+    model_fp = tmp_path / "model.zip"
+    model_fp.write_text("x")
+
+    excel_fp = tmp_path / "roster.xlsx"
+
+    out = learn_roster(
+        demand_csv,
+        excel_fp,
+        forecast_csv=forecast_csv,
+        model_path=model_fp,
+        use_saved_model=True,
+    )
+    assert out is None


### PR DESCRIPTION
## Summary
- guard against failure when loading PPO models in `learn_roster`
- note this behaviour in the README under a new reinforcement learning section
- add regression test covering failed model load

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*