### PR TITLE
Allow safety factor less than 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ parameters:
 - `wage_temp` – hourly cost for temporary staff (default `2200`)
 - `hiring_cost_once` – one‑time cost per hire (default `180000`)
 - `penalty_per_lack_h` – penalty per uncovered hour (default `4000`)
+- `safety_factor` – multiplier applied to shortage hours when converting
+  to required hires (default `1.10`). This is a factor, not an hour count.
 
 If a `leave_analysis.csv` is also present in the output folder you can call
 `merge_shortage_leave(out_dir)` to create `shortage_leave.xlsx`. This file

--- a/app.py
+++ b/app.py
@@ -111,7 +111,7 @@ JP = {
     "ZIP Download": "ZIP形式でダウンロード", "Save to folder": "フォルダに保存",
     "Run Analysis": "▶ 解析実行", "Cost & Hire Parameters": "💰 コスト・採用計画パラメータ",
     "Standard work hours (h/month)": "所定労働時間 (h/月)",
-    "Safety factor (shortage h multiplier)": "安全係数 (不足h上乗せ)",
+    "Safety factor (shortage h multiplier)": "安全係数 (不足h倍率)",
     "Target coverage rate": "目標充足率",
     "Direct employee labor cost (¥/h)": "正職員 人件費 (¥/h)",
     "Temporary staff labor cost (¥/h)": "派遣 人件費 (¥/h)",
@@ -452,7 +452,13 @@ with st.sidebar:
 
     with st.expander(_("Cost & Hire Parameters")):
         st.number_input(_("Standard work hours (h/month)"),   100, 300, key="std_work_hours_widget")
-        st.slider      (_("Safety factor (shortage h multiplier)"), 1.00, 2.00, key="safety_factor_widget")
+        st.slider(
+            _("Safety factor (shortage h multiplier)"),
+            0.00,
+            2.00,
+            key="safety_factor_widget",
+            help="不足時間に乗算する倍率 (例: 1.10 は 10% 上乗せ)"
+        )
         st.slider      (_("Target coverage rate"), 0.50, 1.00, key="target_coverage_widget")
         st.number_input(_("Direct employee labor cost (¥/h)"),   500, 10000, key="wage_direct_widget")
         st.number_input(_("Temporary staff labor cost (¥/h)"),   800, 12000, key="wage_temp_widget")

--- a/shift_suite/tasks/hire_plan.py
+++ b/shift_suite/tasks/hire_plan.py
@@ -6,7 +6,7 @@ hire_plan.py  ── “必要な採用人数” を算出するユーティリ�
 呼出 : build_hire_plan(csv_path       = Path,
                         out_path       = Path,
                         std_work_hours = 160,   # 月あたり所定労働時間
-                        safety_factor  = 1.10,  # 安全係数（10% 上乗せ）
+                        safety_factor  = 1.10,  # 安全係数（不足時間に乗算する倍率。例:1.10は10%増）
                         target_coverage= 0.95)  # シフト充足率の目標
 """
 
@@ -60,7 +60,7 @@ def build_hire_plan(
     )
 
     # 3. 必要採用人数 = 不足時間 / 所定労働時間 / target_coverage
-    #    × 安全係数（切り上げ）
+    #    × 安全係数（倍率として適用し、切り上げ）
     summary["hire_need"] = (
         (summary["lack_h_total"] * safety_factor) / (std_work_hours * target_coverage)
     ).apply(lambda x: int(-(-x // 1)))  # 天井関数 (ceil)


### PR DESCRIPTION
## Summary
- allow safety factors < 1.0 in the Streamlit GUI
- clarify the Japanese label and add slider help text
- document safety_factor parameter in README
- update hire_plan comments about safety factor

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*