### PR TITLE
Switch ExcelFile cache to cache_resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ are automatically imported by `shift_suite/__init__.py`, so you can simply
 - **`leave_analyzer`** – Summarises paid and requested leave days.
 - **`cli_bridge`** – Lightweight CLI for `leave_analyzer` based on CSV input.
 
+The GUI caches the uploaded workbook using `load_excelfile_cached()` with
+`st.cache_resource`, as `pd.ExcelFile` objects cannot be pickled.
+
 ## Usage
 
 1. Install dependencies (requires Python 3.12 or later):

--- a/app.py
+++ b/app.py
@@ -244,9 +244,13 @@ def load_excel_cached(
     )
 
 
-@st.cache_data(show_spinner=False)
+@st.cache_resource(show_spinner=False)
 def load_excelfile_cached(file_path: str, *, file_mtime: float | None = None):
-    """Load ``pd.ExcelFile`` with caching so repeated reads are fast."""
+    """Load ``pd.ExcelFile`` with caching so repeated reads are fast.
+
+    ``pd.ExcelFile`` objects are not picklable so we cache the handle as a
+    resource rather than using ``st.cache_data``.
+    """
     return pd.ExcelFile(file_path)
 
 st.set_page_config(page_title="Shift-Suite", layout="wide", initial_sidebar_state="expanded")

--- a/tests/test_load_excelfile_cached.py
+++ b/tests/test_load_excelfile_cached.py
@@ -1,0 +1,15 @@
+import pandas as pd
+from pathlib import Path
+from app import load_excelfile_cached
+
+def test_load_excelfile_cached(tmp_path: Path):
+    df = pd.DataFrame({"a": [1, 2]})
+    fp = tmp_path / "test.xlsx"
+    df.to_excel(fp, index=False)
+
+    xls = load_excelfile_cached(str(fp), file_mtime=fp.stat().st_mtime)
+    assert isinstance(xls, pd.ExcelFile)
+
+    # Call again to ensure the cached resource is used without pickle errors
+    xls2 = load_excelfile_cached(str(fp), file_mtime=fp.stat().st_mtime)
+    assert isinstance(xls2, pd.ExcelFile)


### PR DESCRIPTION
## Summary
- cache the uploaded Excel workbook via `st.cache_resource` in `load_excelfile_cached`
- document the new cache mechanism in the README
- test that loading an Excel file returns `pd.ExcelFile` and does not raise pickle errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*