### PR TITLE
Clarify hire plan functions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,10 +159,16 @@ chosen range. Use the **選択をクリア** button to reset the selection.
 
 ### Shortage → Hire plan workflow
 
-After `shortage_role.xlsx` is generated, the application now calls
+After `shortage_role.xlsx` is generated, the application automatically runs
 `h2hire.build_hire_plan` to convert shortage hours into required FTE counts.
-The resulting `hire_plan.xlsx` is stored in the same output folder and the
-**Shortage** tab displays these FTE numbers per role.
+This helper ignores the safety factor and simply converts shortage hours to FTE
+hires. The resulting `hire_plan.xlsx` is stored in the same output folder and
+the **Shortage** tab displays these FTE numbers per role.
+
+If you select the optional **Hire plan** module, the application instead calls
+`tasks.hire_plan.build_hire_plan`. This function honours the current value of
+the *Safety factor* slider found under **Cost & Hire Parameters** (range
+`0.00–2.00`, default `1.10`).
 
 The CLI additionally runs a cost/benefit simulation once the hire plan has
 been created. `analyze_cost_benefit(out_dir)` writes `cost_benefit.xlsx`
@@ -173,8 +179,9 @@ parameters:
 - `wage_temp` – hourly cost for temporary staff (default `2200`)
 - `hiring_cost_once` – one‑time cost per hire (default `180000`)
 - `penalty_per_lack_h` – penalty per uncovered hour (default `4000`)
-- `safety_factor` – multiplier applied to shortage hours when converting
-  to required hires (default `1.10`). This is a factor, not an hour count.
+- `safety_factor` – multiplier applied when running
+  `tasks.hire_plan.build_hire_plan` (default `1.10`). This is a factor, not an
+  hour count; the automatically triggered `h2hire.build_hire_plan` ignores it.
 
 If a `leave_analysis.csv` is also present in the output folder you can call
 `merge_shortage_leave(out_dir)` to create `shortage_leave.xlsx`. This file


### PR DESCRIPTION
## Summary
- clarify the two hire plan functions in Shortage → Hire plan workflow
- document safety factor slider range and default
- note that `h2hire.build_hire_plan` ignores the factor

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*