### PR TITLE
Add safety_factor to h2hire hire plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,7 @@ chosen range. Use the **選択をクリア** button to reset the selection.
 
 After `shortage_role.xlsx` is generated, the application automatically runs
 `h2hire.build_hire_plan` to convert shortage hours into required FTE counts.
-This helper ignores the safety factor and simply converts shortage hours to FTE
-hires. The resulting `hire_plan.xlsx` is stored in the same output folder and
+The *Safety factor* slider is also applied here (default `1.0`). The resulting `hire_plan.xlsx` is stored in the same output folder and
 the **Shortage** tab displays these FTE numbers per role.
 
 If you select the optional **Hire plan** module, the application instead calls
@@ -180,8 +179,8 @@ parameters:
 - `hiring_cost_once` – one‑time cost per hire (default `180000`)
 - `penalty_per_lack_h` – penalty per uncovered hour (default `4000`)
 - `safety_factor` – multiplier applied when running
-  `tasks.hire_plan.build_hire_plan` (default `1.10`). This is a factor, not an
-  hour count; the automatically triggered `h2hire.build_hire_plan` ignores it.
+`tasks.hire_plan.build_hire_plan` (default `1.10`). This same value is passed to
+`h2hire.build_hire_plan` when shortage results are converted automatically.
 
 If a `leave_analysis.csv` is also present in the output folder you can call
 `merge_shortage_leave(out_dir)` to create `shortage_leave.xlsx`. This file

--- a/app.py
+++ b/app.py
@@ -672,7 +672,7 @@ if run_button_clicked:
             else:
                 st.success("✅ Shortage (不足分析) 完了")
                 try:
-                    build_hire_plan_from_kpi(out_dir_exec)
+                    build_hire_plan_from_kpi(out_dir_exec, safety_factor=param_safety_factor)
                 except Exception as e:
                     log.warning(f"hire_plan generation error: {e}")
     

--- a/cli.py
+++ b/cli.py
@@ -21,6 +21,12 @@ def main():
     ap.add_argument("--zip", action="store_true")
     ap.add_argument("--holidays-global", help="Global holiday CSV or JSON file")
     ap.add_argument("--holidays-local", help="Local holiday CSV or JSON file")
+    ap.add_argument(
+        "--safety-factor",
+        type=float,
+        default=1.0,
+        help="Multiplier applied to shortage hours when converting to hires",
+    )
     args = ap.parse_args()
 
     excel = Path(args.excel).expanduser()
@@ -83,7 +89,7 @@ def main():
         holidays_local=holiday_dates_local,
     )
     try:
-        build_hire_plan_from_shortage(out)
+        build_hire_plan_from_shortage(out, safety_factor=args.safety_factor)
     except Exception as e:
         print(f"hire_plan generation failed: {e}")
     else:

--- a/tests/test_h2hire.py
+++ b/tests/test_h2hire.py
@@ -1,0 +1,24 @@
+import pandas as pd
+from pathlib import Path
+from shift_suite.tasks.h2hire import build_hire_plan
+
+
+def test_build_hire_plan_safety_factor(tmp_path: Path):
+    df = pd.DataFrame({"role": ["A", "B"], "lack_h": [150, 70]})
+    shortage_fp = tmp_path / "shortage_role.xlsx"
+    df.to_excel(shortage_fp, index=False)
+
+    out_default = build_hire_plan(tmp_path, monthly_hours_fte=100)
+    out_factor1 = build_hire_plan(tmp_path, out_excel="hire_plan_sf1.xlsx", monthly_hours_fte=100, safety_factor=1.0)
+    df_default = pd.read_excel(out_default)
+    df_factor1 = pd.read_excel(out_factor1)
+    pd.testing.assert_frame_equal(df_default, df_factor1)
+
+    out_factor15 = build_hire_plan(
+        tmp_path,
+        out_excel="hire_plan_sf15.xlsx",
+        monthly_hours_fte=100,
+        safety_factor=1.5,
+    )
+    df_factor15 = pd.read_excel(out_factor15)
+    assert list(df_factor15["hire_fte"]) == [3, 2]


### PR DESCRIPTION
## Summary
- allow tuning the shortage multiplier when converting to FTE hires
- apply the slider/CLI value when calling `h2hire.build_hire_plan`
- document the new behaviour
- test that safety_factor behaves as expected

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*