### PR TITLE
Add shortage slider invariance test

### DIFF
--- a/tests/test_shortage_slider.py
+++ b/tests/test_shortage_slider.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from pathlib import Path
+from shift_suite.tasks.shortage import shortage_and_brief
+from shift_suite.tasks.utils import gen_labels
+
+
+def _create_sample_heatmap(out_dir: Path) -> None:
+    """Create a minimal heat_ALL.xlsx for testing."""
+    labels = gen_labels(30)[:2]  # just a couple of slots
+    df = pd.DataFrame({"need": [1, 1], "2024-06-01": [0, 0]}, index=labels)
+    df.to_excel(out_dir / "heat_ALL.xlsx")
+
+
+def test_shortage_time_unchanged_by_slider(tmp_path: Path) -> None:
+    """Verify shortage results are independent of slider-like inputs.
+
+    Running ``shortage_and_brief`` with its default parameters and with
+    an alternate value simulating a slider (empty ``holidays`` list) should
+    produce identical ``shortage_time.xlsx`` files.
+    """
+    _create_sample_heatmap(tmp_path)
+
+    shortage_and_brief(tmp_path, slot=30)
+    df_default = pd.read_excel(tmp_path / "shortage_time.xlsx", index_col=0)
+
+    shortage_and_brief(tmp_path, slot=30, holidays=[])
+    df_slider0 = pd.read_excel(tmp_path / "shortage_time.xlsx", index_col=0)
+
+    pd.testing.assert_frame_equal(df_default, df_slider0)


### PR DESCRIPTION
## Summary
- add a test that runs `shortage_and_brief` twice with different holiday parameters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*