### PR TITLE
Document CLI safety factor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The GUI caches the uploaded workbook using `load_excelfile_cached()` with
 
    ```bash
    python cli.py <excel.xlsx> <out_dir> [--slot MIN] [--header ROW] [--zip] \
-       [--holidays-global FILE] [--holidays-local FILE]
+       [--holidays-global FILE] [--holidays-local FILE] [--safety-factor NUM]
    ```
 
    - `<excel.xlsx>`: path to the source Excel file
@@ -83,6 +83,8 @@ The GUI caches the uploaded workbook using `load_excelfile_cached()` with
    - `--zip`: optionally compress the output directory
    - `--holidays-global`: CSV/JSON with nationally observed holidays
    - `--holidays-local`: CSV/JSON with site-specific holidays
+   - `--safety-factor`: multiplier applied to shortage hours when automatically
+     generating a hire plan (default: 1.0)
 
 4. Run analyses directly on a CSV file using the module entry point:
 
@@ -181,6 +183,7 @@ parameters:
 - `safety_factor` – multiplier applied when running
 `tasks.hire_plan.build_hire_plan` (default `1.10`). This same value is passed to
 `h2hire.build_hire_plan` when shortage results are converted automatically.
+  The value can also be set via the `--safety-factor` CLI option.
 
 If a `leave_analysis.csv` is also present in the output folder you can call
 `merge_shortage_leave(out_dir)` to create `shortage_leave.xlsx`. This file


### PR DESCRIPTION
## Summary
- document `--safety-factor` CLI flag in README
- note how it affects automatic hire-plan generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*