### PR TITLE
Pass hire plan parameters from GUI

### DIFF
--- a/app.py
+++ b/app.py
@@ -671,10 +671,17 @@ if run_button_clicked:
                 st.warning("Shortage (不足分析) の一部または全てが完了しませんでした。")
             else:
                 st.success("✅ Shortage (不足分析) 完了")
-                try:
-                    build_hire_plan_from_kpi(out_dir_exec, safety_factor=param_safety_factor)
-                except Exception as e:
-                    log.warning(f"hire_plan generation error: {e}")
+                if "Hire plan" in param_ext_opts:
+                    try:
+                        build_hire_plan_from_kpi(
+                            out_dir_exec,
+                            monthly_hours_fte=param_std_work_hours,
+                            hourly_wage=param_wage_direct,
+                            recruit_cost=param_hiring_cost,
+                            safety_factor=param_safety_factor,
+                        )
+                    except Exception as e:
+                        log.warning(f"hire_plan generation error: {e}")
     
             # ★----- 休暇分析モジュールの実行 -----★
             # "休暇分析" (日本語) が選択されているか確認

--- a/shift_suite/tasks/h2hire.py
+++ b/shift_suite/tasks/h2hire.py
@@ -45,9 +45,9 @@ def build_hire_plan(
     out_dir        : 解析出力フォルダ（heat_ALL.xlsx 等がある場所）
     shortage_excel : shortage_role.xlsx のファイル名 or パス
     out_excel      : 出力ファイル名
-    hourly_wage    : 自社スタッフの平均時給
-    recruit_cost   : 1 人採用に掛かる固定コスト
-    monthly_hours_fte : 1 FTE が月あたり勤務する時間
+    hourly_wage    : 自社スタッフの平均時給 (default ``AVG_HOURLY_WAGE``)
+    recruit_cost   : 1 人採用に掛かる固定コスト (default ``RECRUIT_COST_PER_HIRE``)
+    monthly_hours_fte : 1 FTE が月あたり勤務する時間 (default ``MONTHLY_HOURS_FTE``)
     safety_factor : 不足時間に乗算する倍率。1.0 で変化なし
 
     Returns


### PR DESCRIPTION
## Summary
- document default constants in `h2hire.build_hire_plan`
- pass work hours, wages and recruit cost when calling `build_hire_plan_from_kpi`
- run KPI based hire plan only when `Hire plan` option is selected

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*