### PR TITLE
Enhance tab display guards

### DIFF
--- a/app.py
+++ b/app.py
@@ -226,6 +226,11 @@ def _file_mtime(path: Path) -> float:
         return 0.0
 
 
+def _valid_df(df: pd.DataFrame) -> bool:
+    """Return True if ``df`` is a non-empty ``pd.DataFrame``."""
+    return isinstance(df, pd.DataFrame) and not df.empty
+
+
 @st.cache_data(show_spinner=False)
 def load_excel_cached(
     file_path: str,
@@ -1008,6 +1013,9 @@ def display_heatmap_tab(tab_container, data_dir):
                     index_col=0,
                     file_mtime=_file_mtime(fp),
                 )
+                if not _valid_df(df_heat):
+                    st.info("Data not available")
+                    return
                 mode_opts = {"Raw": _("Raw Count"), "Ratio": _("Ratio (staff ÷ need)")}
                 mode_lbl = st.radio(_("Display Mode"), list(mode_opts.values()), horizontal=True, key="dash_heat_mode_radio")
                 mode_key = [k for k,v in mode_opts.items() if v == mode_lbl][0]
@@ -1064,6 +1072,9 @@ def display_shortage_tab(tab_container, data_dir):
                 )
                 sheet_role = "role_summary" if "role_summary" in xls.sheet_names else xls.sheet_names[0]
                 df_s_role = xls.parse(sheet_role)
+                if not _valid_df(df_s_role):
+                    st.info("Data not available")
+                    return
                 display_role_df = df_s_role.rename(
                     columns={
                         "role": _("Role"),
@@ -1093,6 +1104,9 @@ def display_shortage_tab(tab_container, data_dir):
                             sheet_name="hire_plan",
                             file_mtime=_file_mtime(fp_hire),
                         )
+                        if not _valid_df(df_hire):
+                            st.info("Data not available")
+                            return
                         if {"role", "hire_fte"}.issubset(df_hire.columns):
                             st.markdown(_("Required FTE per Role"))
                             display_hire_df = df_hire[["role", "hire_fte"]].rename(
@@ -1112,6 +1126,9 @@ def display_shortage_tab(tab_container, data_dir):
 
                 if "role_monthly" in xls.sheet_names:
                     df_month = xls.parse("role_monthly")
+                    if not _valid_df(df_month):
+                        st.info("Data not available")
+                        return
                     if not df_month.empty and {"month", "role", "lack_h"}.issubset(df_month.columns):
                         fig_m = px.bar(
                             df_month,
@@ -1143,6 +1160,9 @@ def display_shortage_tab(tab_container, data_dir):
                     index_col=0,
                     file_mtime=_file_mtime(fp_s_time),
                 )
+                if not _valid_df(df_s_time):
+                    st.info("Data not available")
+                    return
                 st.write(_("Shortage by Time (count per day)"))
                 avail_dates = df_s_time.columns.tolist()
                 if avail_dates:
@@ -1173,6 +1193,9 @@ def display_shortage_tab(tab_container, data_dir):
                     index_col=0,
                     file_mtime=_file_mtime(fp_s_ratio),
                 )
+                if not _valid_df(df_ratio):
+                    st.info("Data not available")
+                    return
                 st.write(_("Shortage Ratio by Time"))
                 avail_ratio_dates = df_ratio.columns.tolist()
                 if avail_ratio_dates:
@@ -1204,6 +1227,9 @@ def display_shortage_tab(tab_container, data_dir):
                     index_col=0,
                     file_mtime=_file_mtime(fp_s_freq),
                 )
+                if not _valid_df(df_freq):
+                    st.info("Data not available")
+                    return
                 st.write(_("Shortage Frequency (days)"))
                 fig_freq = px.bar(
                     df_freq.reset_index(),
@@ -1231,6 +1257,9 @@ def display_shortage_tab(tab_container, data_dir):
                     sheet_name="shortage_leave",
                     file_mtime=_file_mtime(fp_s_leave),
                 )
+                if not _valid_df(df_sl):
+                    st.info("Data not available")
+                    return
                 st.write(_("Shortage with Leave"))
                 display_sl = df_sl.rename(columns={
                     "time": _("Time"),
@@ -1255,6 +1284,9 @@ def display_shortage_tab(tab_container, data_dir):
                     index_col=0,
                     file_mtime=_file_mtime(fp_cost),
                 )
+                if not _valid_df(df_cost):
+                    st.info("Data not available")
+                    return
                 st.write(_("Estimated Cost Impact (Million ¥)"))
                 if "Cost_Million" in df_cost:
                     fig_cost = px.bar(
@@ -1277,6 +1309,9 @@ def display_shortage_tab(tab_container, data_dir):
                 )
                 if "alerts" in xls_stats.sheet_names:
                     df_alerts = xls_stats.parse("alerts")
+                    if not _valid_df(df_alerts):
+                        st.info("Data not available")
+                        return
                     if not df_alerts.empty:
                         st.markdown("---")
                         st.subheader(_("Alerts"))
@@ -1346,6 +1381,9 @@ def display_fairness_tab(tab_container, data_dir):
                     sheet_name="after_summary",
                     file_mtime=_file_mtime(fp),
                 )
+                if not _valid_df(df):
+                    st.info("Data not available")
+                    return
                 display_df = df.rename(columns={"staff": _("Staff"), "night_ratio": _("Night Shift Ratio") if "Night Shift Ratio" in JP else "night_ratio"})
                 st.dataframe(display_df, use_container_width=True, hide_index=True)
                 if "staff" in df and "night_ratio" in df:

--- a/tests/test_app_display_tabs.py
+++ b/tests/test_app_display_tabs.py
@@ -1,0 +1,34 @@
+import types
+import pandas as pd
+from shift_suite import app
+
+class DummyTab:
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+def make_dummy_st():
+    messages = []
+    dummy = types.SimpleNamespace(
+        subheader=lambda *a, **k: None,
+        dataframe=lambda *a, **k: None,
+        plotly_chart=lambda *a, **k: None,
+        radio=lambda *a, **k: None,
+        slider=lambda *a, **k: None,
+        selectbox=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        info=lambda msg: messages.append(msg),
+        columns=lambda *a, **k: [types.SimpleNamespace(metric=lambda *aa, **kk: None) for _ in range(a[0])],
+    )
+    return dummy, messages
+
+
+def test_display_fairness_tab_empty(monkeypatch, tmp_path):
+    (tmp_path / "fairness_after.xlsx").touch()
+    monkeypatch.setattr(app, "load_excel_cached", lambda *a, **k: pd.DataFrame())
+    dummy_st, infos = make_dummy_st()
+    monkeypatch.setattr(app, "st", dummy_st)
+    monkeypatch.setattr(app, "_", lambda x: x)
+    app.display_fairness_tab(DummyTab(), tmp_path)
+    assert "Data not available" in infos[0]


### PR DESCRIPTION
## Summary
- add `_valid_df` helper for DataFrame checks
- guard `display_heatmap_tab`, `display_shortage_tab`, and `display_fairness_tab` against missing/empty data
- add unit test for fairness tab handling of empty data

## Testing
- `ruff check app.py` *(fails: E701/E702 etc. in unrelated files)*
- `pytest -q` *(fails: pandas/numpy not installed)*