### PR TITLE
Fix leave analysis tab call

### DIFF
--- a/app.py
+++ b/app.py
@@ -1607,7 +1607,7 @@ if st.session_state.get("analysis_done", False) and st.session_state.analysis_re
                     if key == "PPT Report":
                         tab_func_map_dash[key](inner_tabs[i], data_dir, key_prefix=fname)
                     elif key == "Leave Analysis":
-                        tab_func_map_dash[key](inner_tabs[i], results.get("leave_analysis_results", {}))
+                        tab_func_map_dash[key](inner_tabs[i], data_dir)
                     else:
                         tab_func_map_dash[key](inner_tabs[i], data_dir)
 
@@ -1679,7 +1679,7 @@ if zip_file_uploaded_dash_final_v3_display_main_dash:
                 if tab_key == "PPT Report":
                     tab_function_map_dash[tab_key](tabs_obj_dash[i], extracted_data_dir, key_prefix="zip")
                 elif tab_key == "Leave Analysis":
-                    tab_function_map_dash[tab_key](tabs_obj_dash[i], {})
+                    tab_function_map_dash[tab_key](tabs_obj_dash[i], extracted_data_dir)
                 else:
                     tab_function_map_dash[tab_key](tabs_obj_dash[i], extracted_data_dir)
             else:

--- a/tests/test_app_display_tabs.py
+++ b/tests/test_app_display_tabs.py
@@ -32,3 +32,13 @@ def test_display_fairness_tab_empty(monkeypatch, tmp_path):
     monkeypatch.setattr(app, "_", lambda x: x)
     app.display_fairness_tab(DummyTab(), tmp_path)
     assert "Data not available" in infos[0]
+
+
+def test_display_leave_analysis_tab_handles_zip(monkeypatch, tmp_path):
+    (tmp_path / "shortage_leave.xlsx").touch()
+    monkeypatch.setattr(app, "load_excel_cached", lambda *a, **k: {})
+    dummy_st, infos = make_dummy_st()
+    monkeypatch.setattr(app, "st", dummy_st)
+    monkeypatch.setattr(app, "_", lambda x: x)
+    app.display_leave_analysis_tab(DummyTab(), tmp_path)
+    assert infos == []


### PR DESCRIPTION
## Summary
- fix parameters passed to `display_leave_analysis_tab`
- test that `display_leave_analysis_tab` works for dashboard ZIP uploads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*