### PR TITLE
Fix optional parse_dates

### DIFF
--- a/app.py
+++ b/app.py
@@ -249,12 +249,10 @@ def load_excel_cached(
     file_mtime: float | None = None,
 ):
     """Load an Excel file with caching based on file path and mtime."""
-    return pd.read_excel(
-        file_path,
-        sheet_name=sheet_name,
-        index_col=index_col,
-        parse_dates=parse_dates,
-    )
+    kwargs = {"sheet_name": sheet_name, "index_col": index_col}
+    if parse_dates is not None:
+        kwargs["parse_dates"] = parse_dates
+    return pd.read_excel(file_path, **kwargs)
 
 
 @st.cache_resource(show_spinner=False)

--- a/tests/test_load_excel_cached.py
+++ b/tests/test_load_excel_cached.py
@@ -1,0 +1,24 @@
+import pandas as pd
+from pathlib import Path
+from app import load_excel_cached
+
+
+def test_load_excel_cached_without_parse_dates(monkeypatch, tmp_path: Path):
+    df = pd.DataFrame({"d": ["2024-01-01"], "v": [1]})
+    fp = tmp_path / "test.xlsx"
+    df.to_excel(fp, index=False)
+
+    real_read_excel = pd.read_excel
+    captured_kwargs = {}
+
+    def fake_read_excel(path, **kwargs):
+        captured_kwargs.update(kwargs)
+        return real_read_excel(path, **kwargs)
+
+    monkeypatch.setattr(pd, "read_excel", fake_read_excel)
+
+    result = load_excel_cached(str(fp), file_mtime=fp.stat().st_mtime)
+
+    assert "parse_dates" not in captured_kwargs
+    pd.testing.assert_frame_equal(result, real_read_excel(fp))
+


### PR DESCRIPTION
## Summary
- only include `parse_dates` when provided in `load_excel_cached`
- add regression test for missing `parse_dates`

## Testing
- `ruff check .` *(fails: many errors)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*