### PR TITLE
Enable Leave Analysis output and tab

### DIFF
--- a/tests/test_app_display_tabs.py
+++ b/tests/test_app_display_tabs.py
@@ -34,9 +34,9 @@ def test_display_fairness_tab_empty(monkeypatch, tmp_path):
     assert "Data not available" in infos[0]
 
 
-def test_display_leave_analysis_tab_handles_zip(monkeypatch, tmp_path):
-    (tmp_path / "shortage_leave.xlsx").touch()
-    monkeypatch.setattr(app, "load_excel_cached", lambda *a, **k: {})
+def test_display_leave_analysis_tab_handles_csv(monkeypatch, tmp_path):
+    df = pd.DataFrame({"date": ["2024-06-01"], "leave_type": ["requested"], "total_leave_days": [2]})
+    (tmp_path / "leave_analysis.csv").write_text(df.to_csv(index=False))
     dummy_st, infos = make_dummy_st()
     monkeypatch.setattr(app, "st", dummy_st)
     monkeypatch.setattr(app, "_", lambda x: x)


### PR DESCRIPTION
## Summary
- ensure leave analysis results get written to `leave_analysis.csv`
- generate `shortage_leave.xlsx` automatically
- fallback to session results when loading the Leave Analysis tab
- update tests accordingly

## Testing
- `pytest tests/test_app_display_tabs.py::test_display_leave_analysis_tab_handles_csv` *(fails: ModuleNotFoundError: No module named 'pandas')*