### PR TITLE
Improve ZIP upload leave analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,3 +194,15 @@ If a `leave_analysis.csv` is also present in the output folder you can call
 combines the per-slot shortage counts with daily leave applicants and adds a
 `net_shortage` column. The Streamlit dashboard automatically visualises this
 table under the **Shortage** tab.
+
+### Uploading ZIP archives
+
+You can inspect past results without rerunning the analyses by uploading a
+compressed ``out`` folder. Use the **Dashboard (Upload ZIP)** section of the GUI
+to drop a ZIP file containing the results. The archive must include at least
+``heat_ALL.xlsx`` and ``leave_analysis.csv`` so the **Leave Analysis** tab can
+render correctly. If ``staff_balance_daily.csv`` or
+``concentration_requested.csv`` are also present they will be loaded directly.
+When these extra files are missing the application reconstructs the
+``staff_balance_daily`` and ``concentration_requested`` tables from
+``leave_analysis.csv`` and ``heat_ALL.xlsx``.

--- a/tests/test_zip_leave_upload.py
+++ b/tests/test_zip_leave_upload.py
@@ -1,0 +1,43 @@
+import pandas as pd
+from pathlib import Path
+import app
+
+
+def _sample_heatmap(path: Path) -> None:
+    df = pd.DataFrame({"need": [0], "2024-06-01": [1], "2024-06-02": [2]})
+    df.to_excel(path / "heat_ALL.xlsx")
+
+
+def test_load_leave_results_reconstructs(tmp_path: Path):
+    _sample_heatmap(tmp_path)
+    leave_df = pd.DataFrame({
+        "date": ["2024-06-01", "2024-06-02"],
+        "leave_type": [app.LEAVE_TYPE_REQUESTED, app.LEAVE_TYPE_REQUESTED],
+        "total_leave_days": [1, 2],
+    })
+    leave_df.to_csv(tmp_path / "leave_analysis.csv", index=False)
+
+    results = app.load_leave_results_from_dir(tmp_path)
+    assert "staff_balance_daily" in results
+    assert "concentration_requested" in results
+    assert len(results["staff_balance_daily"]) == 2
+    assert list(results["concentration_requested"]["leave_applicants_count"]) == [1, 2]
+
+
+def test_load_leave_results_reads_optional_files(tmp_path: Path):
+    _sample_heatmap(tmp_path)
+    leave_df = pd.DataFrame({
+        "date": ["2024-06-01"],
+        "leave_type": [app.LEAVE_TYPE_REQUESTED],
+        "total_leave_days": [1],
+    })
+    leave_df.to_csv(tmp_path / "leave_analysis.csv", index=False)
+
+    staff_df = pd.DataFrame({"date": ["2024-06-01"], "total_staff": [5]})
+    staff_df.to_csv(tmp_path / "staff_balance_daily.csv", index=False)
+    conc_df = pd.DataFrame({"date": ["2024-06-01"], "leave_applicants_count": [1]})
+    conc_df.to_csv(tmp_path / "concentration_requested.csv", index=False)
+
+    results = app.load_leave_results_from_dir(tmp_path)
+    assert results["staff_balance_daily"].iloc[0]["total_staff"] == 5
+    assert results["concentration_requested"].iloc[0]["leave_applicants_count"] == 1


### PR DESCRIPTION
## Summary
- reconstruct or load leave analysis results when a ZIP archive is uploaded
- pass the reconstructed data to `display_leave_analysis_tab`
- explain optional leave CSVs in the README
- test reconstruction logic for ZIP uploads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `./setup.sh` *(fails: Could not find a version that satisfies the requirement pandas==2.2.*)*