### PR TITLE
Add leave summary day counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,17 @@ date,staff,leave_type,leave_day_flag
 
 The GUI displays the same data interactively under the **Leave Analysis** tab.
 
+`summarize_leave_by_day_count` aggregates these daily flags by a chosen period
+and writes `leave_analysis.csv` when ``period="date"``.  The CSV now contains
+the following columns:
+
+- ``date`` (aggregation unit)
+- ``leave_type``
+- ``total_leave_days``
+- ``num_days_in_period_unit`` – number of unique dates in each period
+- ``avg_leave_days_per_day`` – ``total_leave_days`` divided by
+  ``num_days_in_period_unit``
+
 ### 勤務予定人数と希望休取得者数 chart
 
 Within the **Leave Analysis** tab there is a line chart labelled “勤務予定人数と希望休取得者数”.

--- a/tests/test_leave_concentration.py
+++ b/tests/test_leave_concentration.py
@@ -50,5 +50,11 @@ def test_per_date_breakdown_helper_matches_groupby():
         .reset_index(drop=True)
     )
 
-    pd.testing.assert_frame_equal(summary_req, helper_df)
+    expected = helper_df.assign(
+        num_days_in_period_unit=1,
+        avg_leave_days_per_day=helper_df["total_leave_days"] / 1,
+    )
+    expected = expected[summary_req.columns]
+
+    pd.testing.assert_frame_equal(summary_req, expected)
 

--- a/tests/test_leave_summary.py
+++ b/tests/test_leave_summary.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from shift_suite.tasks.leave_analyzer import summarize_leave_by_day_count, LEAVE_TYPE_REQUESTED
+
+
+def test_summary_contains_new_columns():
+    df = pd.DataFrame([
+        {"date": "2024-06-01", "staff": "A", "leave_type": LEAVE_TYPE_REQUESTED, "leave_day_flag": 1},
+        {"date": "2024-06-01", "staff": "B", "leave_type": LEAVE_TYPE_REQUESTED, "leave_day_flag": 1},
+        {"date": "2024-06-02", "staff": "A", "leave_type": LEAVE_TYPE_REQUESTED, "leave_day_flag": 1},
+    ])
+    df["date"] = pd.to_datetime(df["date"])
+
+    summary = summarize_leave_by_day_count(df, period="dayofweek")
+
+    expected_cols = {
+        "period_unit",
+        "leave_type",
+        "total_leave_days",
+        "num_days_in_period_unit",
+        "avg_leave_days_per_day",
+    }
+    assert expected_cols == set(summary.columns)
+    sat = summary.loc[summary["period_unit"] == "土曜日"].iloc[0]
+    assert sat["total_leave_days"] == 2
+    assert sat["num_days_in_period_unit"] == 1
+    assert sat["avg_leave_days_per_day"] == 2


### PR DESCRIPTION
## Summary
- compute unique day counts in `summarize_leave_by_day_count`
- expose `num_days_in_period_unit` and `avg_leave_days_per_day`
- document new CSV columns
- update tests for additional fields and add coverage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*