### PR TITLE
Add joint leave concentration analysis

### DIFF
--- a/shift_suite/tasks/leave_analyzer.py
+++ b/shift_suite/tasks/leave_analyzer.py
@@ -178,6 +178,60 @@ def analyze_leave_concentration(
     return concentration_df[['date', 'leave_applicants_count', 'is_concentrated', 'staff_names']].sort_values(by='date').reset_index(drop=True)
 
 
+def analyze_both_leave_concentration(
+    daily_leave_counts_df: pd.DataFrame,
+    concentration_threshold: int = 3,
+) -> pd.DataFrame:
+    """Evaluate days where both requested and paid leave counts exceed the threshold.
+
+    Parameters
+    ----------
+    daily_leave_counts_df : pd.DataFrame
+        Output from :func:`summarize_leave_by_day_count` with ``period='date'``.
+    concentration_threshold : int, default 3
+        Minimum count for both leave types to mark a day as concentrated.
+
+    Returns
+    -------
+    pd.DataFrame
+        Columns ``date``, ``requested_count``, ``paid_count`` and ``is_concentrated``.
+    """
+
+    required_cols = {"date", "leave_type", "total_leave_days"}
+    if daily_leave_counts_df.empty or not required_cols.issubset(daily_leave_counts_df.columns):
+        logger.warning("Invalid daily_leave_counts_df for analyze_both_leave_concentration")
+        return pd.DataFrame(
+            columns=["date", "requested_count", "paid_count", "is_concentrated"]
+        )
+
+    pivot = (
+        daily_leave_counts_df.pivot(index="date", columns="leave_type", values="total_leave_days")
+        .fillna(0)
+        .rename(
+            columns={
+                LEAVE_TYPE_REQUESTED: "requested_count",
+                LEAVE_TYPE_PAID: "paid_count",
+            }
+        )
+    )
+
+    for col in ["requested_count", "paid_count"]:
+        if col not in pivot.columns:
+            pivot[col] = 0
+
+    pivot = pivot.reset_index()
+    pivot["is_concentrated"] = (
+        (pivot["requested_count"] >= concentration_threshold)
+        & (pivot["paid_count"] >= concentration_threshold)
+    )
+
+    return (
+        pivot[["date", "requested_count", "paid_count", "is_concentrated"]]
+        .sort_values("date")
+        .reset_index(drop=True)
+    )
+
+
 def get_staff_leave_list(
     long_df: pd.DataFrame,
     target_leave_types: List[str] = [LEAVE_TYPE_REQUESTED, LEAVE_TYPE_PAID]

--- a/tests/test_leave_concentration.py
+++ b/tests/test_leave_concentration.py
@@ -1,8 +1,10 @@
 import pandas as pd
 from shift_suite.tasks.leave_analyzer import (
     analyze_leave_concentration,
+    analyze_both_leave_concentration,
     summarize_leave_by_day_count,
     LEAVE_TYPE_REQUESTED,
+    LEAVE_TYPE_PAID,
 )
 
 
@@ -14,6 +16,20 @@ def make_sample_daily_leave_df():
         {"date": "2024-06-03", "staff": "Bob", "leave_type": LEAVE_TYPE_REQUESTED, "leave_day_flag": 1},
         {"date": "2024-06-03", "staff": "Charlie", "leave_type": LEAVE_TYPE_REQUESTED, "leave_day_flag": 1},
         {"date": "2024-06-04", "staff": "Alice", "leave_type": "有給", "leave_day_flag": 1},
+    ]
+    df = pd.DataFrame(data)
+    df["date"] = pd.to_datetime(df["date"])
+    return df
+
+
+def make_sample_both_leave_df():
+    data = [
+        {"date": "2024-06-01", "staff": "A", "leave_type": LEAVE_TYPE_REQUESTED, "leave_day_flag": 1},
+        {"date": "2024-06-01", "staff": "B", "leave_type": LEAVE_TYPE_PAID, "leave_day_flag": 1},
+        {"date": "2024-06-02", "staff": "A", "leave_type": LEAVE_TYPE_REQUESTED, "leave_day_flag": 1},
+        {"date": "2024-06-02", "staff": "B", "leave_type": LEAVE_TYPE_REQUESTED, "leave_day_flag": 1},
+        {"date": "2024-06-02", "staff": "C", "leave_type": LEAVE_TYPE_PAID, "leave_day_flag": 1},
+        {"date": "2024-06-03", "staff": "D", "leave_type": LEAVE_TYPE_PAID, "leave_day_flag": 1},
     ]
     df = pd.DataFrame(data)
     df["date"] = pd.to_datetime(df["date"])
@@ -51,4 +67,14 @@ def test_per_date_breakdown_helper_matches_groupby():
     )
 
     pd.testing.assert_frame_equal(summary_req, helper_df)
+
+
+def test_analyze_both_leave_concentration():
+    df = make_sample_both_leave_df()
+    summary = summarize_leave_by_day_count(df, period="date")
+    result = analyze_both_leave_concentration(summary, concentration_threshold=1)
+
+    assert list(result["is_concentrated"]) == [True, True, False]
+    assert result["requested_count"].tolist() == [1, 2, 0]
+    assert result["paid_count"].tolist() == [1, 1, 1]
 

--- a/tests/test_zip_leave_upload.py
+++ b/tests/test_zip_leave_upload.py
@@ -20,8 +20,10 @@ def test_load_leave_results_reconstructs(tmp_path: Path):
     results = app.load_leave_results_from_dir(tmp_path)
     assert "staff_balance_daily" in results
     assert "concentration_requested" in results
+    assert "concentration_both" in results
     assert len(results["staff_balance_daily"]) == 2
     assert list(results["concentration_requested"]["leave_applicants_count"]) == [1, 2]
+    assert list(results["concentration_both"]["paid_count"]) == [0, 0]
 
 
 def test_load_leave_results_reads_optional_files(tmp_path: Path):
@@ -41,3 +43,4 @@ def test_load_leave_results_reads_optional_files(tmp_path: Path):
     results = app.load_leave_results_from_dir(tmp_path)
     assert results["staff_balance_daily"].iloc[0]["total_staff"] == 5
     assert results["concentration_requested"].iloc[0]["leave_applicants_count"] == 1
+    assert "concentration_both" in results


### PR DESCRIPTION
## Summary
- add `analyze_both_leave_concentration` helper
- show both requested and paid leave concentration analysis in the dashboard
- reconstruct new table when loading historical leave results
- tests for helper and loader logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*