### PR TITLE
Fix benchmark imports

### DIFF
--- a/shift_suite/tasks/benchmark.py
+++ b/shift_suite/tasks/benchmark.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 import pandas as pd
 from pathlib import Path
-import json, datetime as dt
+import json
 from .utils import log, derive_min_staff
 
 def _meta(p: Path) -> dict:


### PR DESCRIPTION
## Summary
- tidy imports in `benchmark.py`

## Testing
- `ruff check .` *(fails: E701 etc.)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683d070ac24c8333b933d584559ba80b