### PR TITLE
Update docs for setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,8 @@
 The root of this repository contains utilities for analysing Excel shift schedules. When modifying code or documentation, follow these rules.
 
 ## Programmatic checks
-Run the following commands from the repository root after your changes:
+Run the following commands from the repository root after your changes.
+Install dependencies via `./setup.sh` or `pip install -r requirements.txt` before running them if needed:
 
 ```bash
 ruff check .

--- a/README.md
+++ b/README.md
@@ -217,3 +217,17 @@ render correctly. If ``staff_balance_daily.csv`` or
 When these extra files are missing the application reconstructs the
 ``staff_balance_daily`` and ``concentration_requested`` tables from
 ``leave_analysis.csv`` and ``heat_ALL.xlsx``.
+
+### Running tests
+
+Install the dependencies first:
+
+```bash
+./setup.sh  # or pip install -r requirements.txt
+```
+
+Then execute the test suite with:
+
+```bash
+pytest -q
+```


### PR DESCRIPTION
## Summary
- clarify how to install requirements before running tests in AGENTS.md
- add a section in README about installing dependencies prior to tests

## Testing
- `ruff check .` *(fails: E701 etc.)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683d071b8ac88333bd8e57f4e4d916f8