### PR TITLE
Support employment type column

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,13 @@ The GUI caches the uploaded workbook using `load_excelfile_cached()` with
    - `--zip`: optionally compress the output directory
    - `--holidays-global`: CSV/JSON with nationally observed holidays
    - `--holidays-local`: CSV/JSON with site-specific holidays
+
    - `--safety-factor`: multiplier applied to shortage hours when automatically
      generating a hire plan (default: 1.0)
+
+   Each shift sheet should include columns for staff name, role and employment
+   type. The employment type must be one of `正社員`, `パート`, `派遣`, `スポット`
+   or `その他`.
 
 4. Run analyses directly on a CSV file using the module entry point:
 

--- a/shift_suite/tasks/io_excel.py
+++ b/shift_suite/tasks/io_excel.py
@@ -49,6 +49,8 @@ SHEET_COL_ALIAS = {
     "部署": "role",
     "役職": "role",
     "role": "role",
+    "雇用形態": "employment",
+    "employment": "employment",
 }
 DOW_TOKENS = {"月", "火", "水", "木", "金", "土", "日", "明"}
 
@@ -242,7 +244,9 @@ def ingest_excel(
         date_cols_candidate = [
             c
             for c in df_sheet.columns
-            if c not in ("staff", "role") and not str(c).startswith("Unnamed:")
+            if c
+            not in ("staff", "role", "employment")
+            and not str(c).startswith("Unnamed:")
         ]
         if not date_cols_candidate:
             logger.warning(
@@ -256,6 +260,7 @@ def ingest_excel(
         for _, row_data in df_sheet.iterrows():
             staff = _normalize(row_data.get("staff", ""))
             role = _normalize(row_data.get("role", ""))
+            employment = _normalize(row_data.get("employment", ""))
 
             if (
                 staff in DOW_TOKENS
@@ -392,6 +397,7 @@ def ingest_excel(
                             "ds": record_datetime_for_zero_slot,
                             "staff": staff,
                             "role": role,
+                            "employment": employment,
                             "code": code_val,
                             "holiday_type": holiday_type_for_record,
                             "parsed_slots_count": parsed_slots_count_for_record,
@@ -410,6 +416,7 @@ def ingest_excel(
                                 "ds": record_datetime,
                                 "staff": staff,
                                 "role": role,
+                                "employment": employment,
                                 "code": code_val,
                                 "holiday_type": holiday_type_for_record,
                                 "parsed_slots_count": parsed_slots_count_for_record,

--- a/tests/test_ingest_employment.py
+++ b/tests/test_ingest_employment.py
@@ -1,0 +1,23 @@
+import pandas as pd
+from pathlib import Path
+from shift_suite.tasks.io_excel import ingest_excel
+
+
+def test_ingest_excel_employment(tmp_path: Path):
+    excel_fp = tmp_path / "shift.xlsx"
+
+    wt = pd.DataFrame({"勤務記号": ["A"], "開始": ["09:00"], "終了": ["18:00"]})
+    df = pd.DataFrame({
+        "氏名": ["山田"],
+        "職種": ["看護師"],
+        "雇用形態": ["正社員"],
+        "2024-01-01": ["A"],
+    })
+    with pd.ExcelWriter(excel_fp) as writer:
+        wt.to_excel(writer, sheet_name="勤務区分", index=False)
+        df.to_excel(writer, sheet_name="Sheet1", index=False)
+
+    long_df, _ = ingest_excel(excel_fp, shift_sheets=["Sheet1"], header_row=1)
+    assert "employment" in long_df.columns
+    assert set(long_df["employment"]) == {"正社員"}
+


### PR DESCRIPTION
## Summary
- support an optional `employment` column when ingesting Excel shifts
- note required columns in the README
- add a regression test for the new column

## Testing
- `ruff check .`
- `pytest -q tests/test_ingest_employment.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683d306da9d08333a7f92e6de3d15628