### PR TITLE
Add employment-based shortage analysis

### DIFF
--- a/tests/test_shortage_employment.py
+++ b/tests/test_shortage_employment.py
@@ -1,0 +1,22 @@
+import pandas as pd
+from pathlib import Path
+from shift_suite.tasks.shortage import shortage_and_brief
+from shift_suite.tasks.utils import gen_labels
+
+
+def _create_heatmaps(out_dir: Path) -> None:
+    labels = gen_labels(30)[:2]
+    df_all = pd.DataFrame({"need": [1, 1], "2024-06-01": [1, 1]}, index=labels)
+    df_all.to_excel(out_dir / "heat_ALL.xlsx")
+    df_emp = pd.DataFrame({"need": [1, 1], "2024-06-01": [1, 1]}, index=labels)
+    df_emp.to_excel(out_dir / "heat_emp_Fulltime.xlsx")
+
+
+def test_shortage_employment_output(tmp_path: Path) -> None:
+    _create_heatmaps(tmp_path)
+    shortage_and_brief(tmp_path, slot=30)
+    fp = tmp_path / "shortage_employment.xlsx"
+    assert fp.exists()
+    df = pd.read_excel(fp, sheet_name="employment_summary")
+    assert "employment" in df.columns
+


### PR DESCRIPTION
## Summary
- support employment-specific heatmaps in `build_heatmap`
- compute shortage metrics by employment type
- show employment shortage results in Streamlit GUI
- test generation of `shortage_employment.xlsx`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_683d379395fc833386c84b8213c084ba