### PR TITLE
Fix logging formatting and undefined variable

### DIFF
--- a/app.py
+++ b/app.py
@@ -1393,7 +1393,7 @@ if run_button_clicked:
                             )
         else:
             log.warning(
-                f"解析は完了しましたが、出力ディレクトリ '{out_dir_to_save_exec_main_run}' が見つかりません。"
+                f"解析は完了しましたが、出力ディレクトリ '{st.session_state.out_dir_path_str}' が見つかりません。"
             )
 
         st.session_state.analysis_results[file_name] = {

--- a/shift_suite/tasks/shortage.py
+++ b/shift_suite/tasks/shortage.py
@@ -746,13 +746,14 @@ def shortage_and_brief(
     )
 
     log.info(
-        f"[shortage] completed — shortage_time → {fp_shortage_time.name}, "
-        f"shortage_ratio → {fp_shortage_ratio.name}, "
-        f"shortage_freq → {fp_shortage_freq.name}, "
-        f"shortage_role → {fp_shortage_role.name}, "
-        f"shortage_employment → {fp_shortage_emp.name}, "(
-            f"excess_time → {fp_excess_time.name}, " if fp_excess_time else ""
+        (
+            f"[shortage] completed — shortage_time → {fp_shortage_time.name}, "
+            f"shortage_ratio → {fp_shortage_ratio.name}, "
+            f"shortage_freq → {fp_shortage_freq.name}, "
+            f"shortage_role → {fp_shortage_role.name}, "
+            f"shortage_employment → {fp_shortage_emp.name}, "
         )
+        + (f"excess_time → {fp_excess_time.name}, " if fp_excess_time else "")
         + (f"excess_ratio → {fp_excess_ratio.name}, " if fp_excess_ratio else "")
         + (f"excess_freq → {fp_excess_freq.name}" if fp_excess_freq else "")
     )


### PR DESCRIPTION
## Summary
- fix concatenation bug in shortage log message
- reference session state path directly in warning log

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683d3fedace08333b96a7ccc00071a22