### PR TITLE
Improve data loader error handling

### DIFF
--- a/shift_suite/tasks/data_loader.py
+++ b/shift_suite/tasks/data_loader.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging
 
 import pandas as pd
+
+log = logging.getLogger(__name__)
 
 
 class ShiftDataLoader:
@@ -13,4 +16,20 @@ class ShiftDataLoader:
 
     def load(self) -> pd.DataFrame:
         """Load the CSV file into a DataFrame."""
-        return pd.read_csv(self.csv_path, parse_dates=["ds"])
+        if not self.csv_path.exists():
+            log.error("CSV file not found: %s", self.csv_path)
+            raise FileNotFoundError(self.csv_path)
+
+        try:
+            df = pd.read_csv(self.csv_path, parse_dates=["ds"])
+        except Exception as e:  # pragma: no cover - network/file errors
+            log.error("Failed to read CSV %s: %s", self.csv_path, e)
+            raise
+
+        if "ds" not in df.columns:
+            log.warning("Column 'ds' missing in %s", self.csv_path)
+
+        if df.empty:
+            log.warning("CSV contains no rows: %s", self.csv_path)
+
+        return df


### PR DESCRIPTION
## Summary
- add logger and error handling to `ShiftDataLoader`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683e9c772290833395050a91c7ebb3ce