### PR TITLE
Add linting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,3 +244,11 @@ Then execute the test suite with:
 ```bash
 pytest -q
 ```
+
+### Linting
+
+Check code style with [ruff](https://docs.astral.sh/ruff/):
+
+```bash
+ruff check .
+```


### PR DESCRIPTION
## Summary
- document `ruff` style checks in README

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6840044552348333b7a9307bf533ab9d