### PR TITLE
Improve Japanese labels for graphs

### DIFF
--- a/dash_app.py
+++ b/dash_app.py
@@ -19,6 +19,31 @@ import numpy as np  # ★ 追加: np.nan のため
 import logging
 from shift_suite.tasks.constants import SUMMARY5 as SUMMARY5_CONST
 
+# --- 簡易日本語ラベル辞書 -----------------------------------------------
+JP = {
+    "Overview": "概要",
+    "Heatmap": "ヒートマップ",
+    "Shortage": "不足分析",
+    "Heatmap Data Not Found": "ヒートマップデータが見つかりません",
+    "Please run the analysis via the Streamlit app first and ensure 'out/heat_ALL.xlsx' exists.": "Streamlit app.py を先に実行し 'out/heat_ALL.xlsx' を生成してください。",
+    "Shortage Ratio Data Not Found": "不足率データが見つかりません",
+    "Run analysis via the Streamlit app to generate shortage_ratio.xlsx": "Streamlit app で解析を実行し shortage_ratio.xlsx を生成してください",
+    "Shortage Ratio Heatmap": "不足率ヒートマップ",
+    "Time Slot Shortage Ratio": "時間帯別不足率",
+    "Date": "日付",
+    "Time": "時間帯",
+    "Shortage Ratio": "不足率",
+    "Manual": "手動",
+    "90th %tile": "90パーセンタイル",
+    "95th %tile": "95パーセンタイル",
+    "99th %tile": "99パーセンタイル",
+}
+
+
+def _(text: str) -> str:
+    """Translate ``text`` using ``JP`` dictionary."""
+    return JP.get(text, text)
+
 logger = logging.getLogger(__name__)
 
 # ────────────────── 1. 定数 & ヘルパ ──────────────────
@@ -115,10 +140,10 @@ server = app.server
 NAV = html.Div(
     [
         dcc.Link(
-            "Overview", href="/", className="nav-link me-2"
+            _("Overview"), href="/", className="nav-link me-2"
         ),  # ★ class変更 (Bootstrap風)
-        dcc.Link("Heatmap", href="/heat", className="nav-link me-2"),
-        dcc.Link("Shortage", href="/short", className="nav-link me-2"),
+        dcc.Link(_("Heatmap"), href="/heat", className="nav-link me-2"),
+        dcc.Link(_("Shortage"), href="/short", className="nav-link me-2"),
         # ... (他のナビゲーションリンクも同様に)
     ],
     className="d-flex flex-wrap p-2 bg-light border-bottom",  # ★ Bootstrapクラス追加
@@ -160,16 +185,18 @@ def page_overview():
         )
     if not cards:
         cards.append(html.Div("KPIデータがありません", className="p-3"))
-    return html.Div([html.H3("Overview"), html.Div(cards, className="d-flex")])
+    return html.Div([html.H3(_("Overview")), html.Div(cards, className="d-flex")])
 
 
 def page_heat():
     if heat_staff_data.empty:  # ★ データロード失敗時の表示
         return html.Div(
             [
-                html.H4("Heatmap Data Not Found"),
+                html.H4(_("Heatmap Data Not Found")),
                 html.P(
-                    "Please run the analysis via the Streamlit app first and ensure 'out/heat_ALL.xlsx' exists."
+                    _(
+                        "Please run the analysis via the Streamlit app first and ensure 'out/heat_ALL.xlsx' exists."
+                    )
                 ),
             ]
         )
@@ -191,10 +218,10 @@ def page_heat():
                     dcc.Dropdown(
                         id="hm-zmax-mode",
                         options=[
-                            {"label": "Manual", "value": "manual"},
-                            {"label": "90th %tile", "value": "p90"},
-                            {"label": "95th %tile", "value": "p95"},
-                            {"label": "99th %tile", "value": "p99"},
+                            {"label": _("Manual"), "value": "manual"},
+                            {"label": _("90th %tile"), "value": "p90"},
+                            {"label": _("95th %tile"), "value": "p95"},
+                            {"label": _("99th %tile"), "value": "p99"},
                         ],
                         value="manual",
                         clearable=False,
@@ -243,16 +270,18 @@ def page_shortage():
     if shortage_ratio_df.empty:
         return html.Div(
             [
-                html.H4("Shortage Ratio Data Not Found"),
+                html.H4(_("Shortage Ratio Data Not Found")),
                 html.P(
-                    "Run analysis via the Streamlit app to generate shortage_ratio.xlsx"
+                    _(
+                        "Run analysis via the Streamlit app to generate shortage_ratio.xlsx"
+                    )
                 ),
             ]
         )
 
     return html.Div(
         [
-            html.H3("Shortage Ratio Heatmap"),
+            html.H3(_("Shortage Ratio Heatmap")),
             dcc.Graph(
                 id="shortage-ratio-heatmap",
                 figure=px.imshow(
@@ -261,11 +290,11 @@ def page_shortage():
                     color_continuous_scale=px.colors.sequential.OrRd,
                     zmin=0,
                     zmax=1,
-                    labels=dict(x="Date", y="Time", color="Shortage Ratio"),
+                    labels=dict(x=_("Date"), y=_("Time"), color=_("Shortage Ratio")),
                 ),
             ),
             html.Hr(),
-            html.H4("Time Slot Shortage Ratio"),
+            html.H4(_("Time Slot Shortage Ratio")),
             dcc.Dropdown(
                 id="shortage-ratio-date-dropdown",
                 options=[

--- a/shift_suite/tasks/dashboard.py
+++ b/shift_suite/tasks/dashboard.py
@@ -12,6 +12,12 @@ JP = {
     "Total Leave Days": "総休暇日数",
     "Shift Code": "勤務区分",
     "Ratio": "比率",
+    "Combined Score by Staff": "スタッフ別総合スコア",
+    "Average Score by Role": "職種別平均スコア",
+    "No data": "データなし",
+    "Fatigue Score Distribution": "疲労スコア分布",
+    "Night Shift Ratio Distribution": "夜勤比率分布",
+    "Count": "件数",
 }
 
 
@@ -22,12 +28,12 @@ def _(text: str) -> str:
 def employee_overview(score_df: pd.DataFrame):
     """Return a bar chart of final scores per staff."""
     if score_df is None or score_df.empty:
-        return px.bar(title="No data")
+        return px.bar(title=_("No data"))
     fig = px.bar(
         score_df,
         x="staff",
         y="final_score",
-        title="Combined Score by Staff",
+        title=_("Combined Score by Staff"),
         labels={"staff": _("Staff"), "final_score": _("Score")},
     )
     fig.update_layout(xaxis_title=_("Staff"), yaxis_title=_("Score"))
@@ -43,7 +49,7 @@ def department_overview(score_df: pd.DataFrame, long_df: pd.DataFrame):
         or long_df.empty
         or "role" not in long_df.columns
     ):
-        return px.bar(title="No data")
+        return px.bar(title=_("No data"))
     mapping = long_df[["staff", "role"]].drop_duplicates()
     merged = mapping.merge(score_df, on="staff", how="left")
     dept = merged.groupby("role")["final_score"].mean().reset_index()
@@ -51,7 +57,7 @@ def department_overview(score_df: pd.DataFrame, long_df: pd.DataFrame):
         dept,
         x="role",
         y="final_score",
-        title="Average Score by Role",
+        title=_("Average Score by Role"),
         labels={"role": _("Role"), "final_score": _("Score")},
     )
     fig.update_layout(xaxis_title=_("Role"), yaxis_title=_("Score"))
@@ -109,9 +115,9 @@ def fatigue_distribution(fatigue_df: pd.DataFrame):
         x="fatigue_score",
         nbins=20,
         labels={"fatigue_score": _("Score")},
-        title="Fatigue Score Distribution",
+        title=_("Fatigue Score Distribution"),
     )
-    fig.update_layout(yaxis_title="Count")
+    fig.update_layout(yaxis_title=_("Count"))
     return fig
 
 
@@ -125,7 +131,7 @@ def fairness_histogram(summary_df: pd.DataFrame, metric: str = "night_ratio"):
         x=metric,
         nbins=20,
         labels={metric: _("Ratio") if metric == "night_ratio" else _(metric)},
-        title="Night Shift Ratio Distribution" if metric == "night_ratio" else f"{metric} Distribution",
+        title=_("Night Shift Ratio Distribution") if metric == "night_ratio" else f"{metric} Distribution",
     )
-    fig.update_layout(yaxis_title="Count")
+    fig.update_layout(yaxis_title=_("Count"))
     return fig


### PR DESCRIPTION
## Summary
- add JP dictionary in `dash_app.py` and translate navigation and messages
- translate dropdown options and shortage graph titles in `dash_app.py`
- localise titles and labels in `dashboard.py`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6840010f400083338af45c34231c646f