### PR TITLE
Add type hints to I/O helpers

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,7 +28,7 @@ import sys
 import tempfile
 import zipfile
 from pathlib import Path
-from typing import Optional
+from typing import IO, Optional, Sequence
 
 import pandas as pd
 import streamlit as st
@@ -286,9 +286,9 @@ def load_excel_cached(
     *,
     sheet_name: str | int | None = 0,
     index_col: int | str | None = None,
-    parse_dates=None,
+    parse_dates: Sequence[int | str] | bool | None = None,
     file_mtime: float | None = None,
-):
+) -> pd.DataFrame:
     """Load an Excel file with caching based on file path and mtime."""
     kwargs = {"sheet_name": sheet_name, "index_col": index_col}
     if parse_dates is not None:
@@ -297,7 +297,7 @@ def load_excel_cached(
 
 
 @st.cache_resource(show_spinner=False)
-def load_excelfile_cached(file_path: str, *, file_mtime: float | None = None):
+def load_excelfile_cached(file_path: str, *, file_mtime: float | None = None) -> pd.ExcelFile:
     """Load ``pd.ExcelFile`` with caching so repeated reads are fast.
 
     ``pd.ExcelFile`` objects are not picklable so we cache the handle as a
@@ -720,7 +720,8 @@ if run_button_clicked:
     holiday_dates_global_for_run = None
     holiday_dates_local_for_run = None
 
-    def _read_holiday_upload(uploaded_file):
+    def _read_holiday_upload(uploaded_file: IO[str | bytes]) -> list[dt.date]:
+        """Return dates from an uploaded CSV or JSON file."""
         if uploaded_file.name.lower().endswith(".json"):
             import json
 

--- a/shift_suite/tasks/utils.py
+++ b/shift_suite/tasks/utils.py
@@ -48,9 +48,7 @@ log = logging.getLogger("shift_suite")
 
 
 # ────────────────── 2. Excel 日付ユーティリティ ──────────────────
-def excel_date(
-    excel_serial,
-) -> dt.date | None:  # ★ datetime → dt.date に変更 (日付のみ返すため)
+def excel_date(excel_serial: Any) -> dt.date | None:
     """Excel 1900 シリアル or pandas.Timestamp 等 → date"""  # ★ docstring変更
     if excel_serial in (None, "", np.nan):
         return None
@@ -65,7 +63,7 @@ def excel_date(
         return None
 
 
-def to_hhmm(x) -> str | None:
+def to_hhmm(x: Any) -> str | None:
     """8.5 → '08:30' / '23:45' → '23:45' / Excel シリアルなど柔軟変換"""
     if x in (None, "", np.nan):
         return None


### PR DESCRIPTION
## Summary
- annotate uploaded file parsing in app.py
- add return types and parse_dates type hints for cached Excel loaders
- note parameter types in utils helpers

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68403f1dcbf48333981d3b488fee991c