### PR TITLE
Add coverage docs and minimal utils tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,12 @@ Then execute the test suite with:
 pytest -q
 ```
 
+To generate a coverage report, install ``pytest-cov`` and run:
+
+```bash
+pytest --cov=shift_suite --cov-report=term-missing
+```
+
 ### Linting
 
 Check code style with [ruff](https://docs.astral.sh/ruff/):

--- a/setup.sh
+++ b/setup.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
 pip install -r requirements.txt
+pip install pytest-cov

--- a/tests/test_utils_basic.py
+++ b/tests/test_utils_basic.py
@@ -1,0 +1,29 @@
+import importlib
+import sys
+import types
+import datetime as dt
+
+# Provide minimal pandas/numpy stubs so the module can be imported without the real dependencies
+fake_pd = types.SimpleNamespace(
+    Timestamp=lambda x: types.SimpleNamespace(to_pydatetime=lambda: dt.datetime.fromtimestamp(float(x))),
+    to_datetime=lambda x, errors="raise": dt.datetime.fromisoformat(x),
+    DataFrame=object,
+    Series=object,
+)
+fake_np = types.SimpleNamespace(nan=float("nan"))
+sys.modules.setdefault("pandas", fake_pd)
+sys.modules.setdefault("numpy", fake_np)
+
+utils = importlib.import_module("shift_suite.tasks.utils")
+
+
+def test_excel_date_serial():
+    d = utils.excel_date(1)
+    assert d == dt.date(1899, 12, 31)
+
+
+def test_to_hhmm_variants():
+    assert utils.to_hhmm(8.5) == "08:30"
+    assert utils.to_hhmm("23:45") == "23:45"
+    assert utils.to_hhmm("12:00:59") == "12:00"
+    assert utils.to_hhmm(None) is None


### PR DESCRIPTION
## Summary
- document coverage generation using pytest-cov
- install pytest-cov in `setup.sh`
- add a lightweight test for `shift_suite.tasks.utils`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684046b880ac83338c9b8a7061d5ac40