### PR TITLE
Refactor logger variable names

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10,7 +10,7 @@ from shift_suite.h2hire import build_hire_plan as build_hire_plan_from_shortage
 from shift_suite.tasks.cost_benefit import analyze_cost_benefit
 from shift_suite.utils import safe_make_archive
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 def main():
@@ -59,14 +59,14 @@ def main():
         try:
             holiday_dates_global = _read_holiday_file(fp_hg)
         except Exception as e:
-            logger.error("Failed to read holidays from %s: %s", fp_hg, e)
+            log.error("Failed to read holidays from %s: %s", fp_hg, e)
 
     if args.holidays_local:
         fp_hl = Path(args.holidays_local).expanduser()
         try:
             holiday_dates_local = _read_holiday_file(fp_hl)
         except Exception as e:
-            logger.error("Failed to read holidays from %s: %s", fp_hl, e)
+            log.error("Failed to read holidays from %s: %s", fp_hl, e)
     shutil.rmtree(out, ignore_errors=True)
 
     # Determine shift sheet names by excluding the master sheet
@@ -104,18 +104,18 @@ def main():
     try:
         build_hire_plan_from_shortage(out, safety_factor=args.safety_factor)
     except Exception as e:
-        logger.error("hire_plan generation failed: %s", e)
+        log.error("hire_plan generation failed: %s", e)
     else:
         try:
             analyze_cost_benefit(out)
         except Exception as e:
-            logger.error("cost-benefit analysis failed: %s", e)
+            log.error("cost-benefit analysis failed: %s", e)
     summary.build_staff_stats(long, out)
 
     if args.zip:
         safe_make_archive(out, out.with_suffix(".zip"))
 
-    logger.info("✔ CLI done → %s", out)
+    log.info("✔ CLI done → %s", out)
 
 
 if __name__ == "__main__":

--- a/dash_app.py
+++ b/dash_app.py
@@ -23,7 +23,7 @@ from shift_suite.tasks.dashboard import load_leave_results_from_dir
 
 # --- 日本語ラベル辞書は resources/strings_ja.json で管理 ---
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 # ────────────────── 1. 定数 & ヘルパ ──────────────────
 DATA_DIR = pathlib.Path(__file__).resolve().parents[1] / "out"  # ★ .resolve() を追加
@@ -77,7 +77,7 @@ try:
             if "lack_h" in df_sr:
                 kpi_lack_h = float(df_sr["lack_h"].sum())
         except Exception as e:
-            logger.error("shortage_role.xlsx 読込エラー: %s", e)
+            log.error("shortage_role.xlsx 読込エラー: %s", e)
     if (DATA_DIR / "fairness_before.xlsx").exists():
         try:
             df_fb = pd.read_excel(
@@ -87,12 +87,12 @@ try:
             if not row.empty:
                 jain_index_val = float(row["value"].iloc[0])
         except Exception as e:
-            logger.error("fairness_before.xlsx 読込エラー: %s", e)
+            log.error("fairness_before.xlsx 読込エラー: %s", e)
 
     leave_results = load_leave_results_from_dir(DATA_DIR)
 
 except FileNotFoundError:
-    logger.error(
+    log.error(
         "エラー: %s が見つかりません。先にstreamlit app.pyで解析を実行してください。",
         DATA_DIR / "heat_ALL.xlsx",
     )
@@ -106,7 +106,7 @@ except FileNotFoundError:
     leave_results = {}
     # ... (他のDFも空で初期化)
 except Exception as e:
-    logger.error("データロード中に予期せぬエラーが発生しました: %s", e)
+    log.error("データロード中に予期せぬエラーが発生しました: %s", e)
     heat_all_df = pd.DataFrame()
     heat_staff_data = pd.DataFrame()
     ratio_calculated_df = pd.DataFrame()

--- a/shift_suite/tasks/cli_bridge.py
+++ b/shift_suite/tasks/cli_bridge.py
@@ -16,7 +16,7 @@ from .analyzers import (
 )
 
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 DEF_CHOICES = ["leave", "rest", "work", "attendance", "score", "lowstaff", "all"]
 
@@ -51,7 +51,7 @@ def main(argv: list[str] | None = None) -> list[Path]:
         leave_res = LeaveAnalyzer().analyze(df)
         fp = out_dir / "leave_analysis.csv"
         leave_res.to_csv(fp, index=False)
-        logger.info("Results saved to %s", fp)
+        log.info("Results saved to %s", fp)
         results.append(fp)
 
     if args.analysis in ("rest", "score", "all"):
@@ -59,14 +59,14 @@ def main(argv: list[str] | None = None) -> list[Path]:
         rest_res = rta.analyze(df)
         fp = out_dir / "rest_time.csv"
         rest_res.to_csv(fp, index=False)
-        logger.info("Results saved to %s", fp)
+        log.info("Results saved to %s", fp)
         results.append(fp)
 
         monthly_rest = rta.monthly(rest_res)
         if not monthly_rest.empty:
             fp_m = out_dir / "rest_time_monthly.csv"
             monthly_rest.to_csv(fp_m, index=False)
-            logger.info("Results saved to %s", fp_m)
+            log.info("Results saved to %s", fp_m)
             results.append(fp_m)
     else:
         rest_res = None
@@ -76,14 +76,14 @@ def main(argv: list[str] | None = None) -> list[Path]:
         work_res = wpa.analyze(df)
         fp = out_dir / "work_patterns.csv"
         work_res.to_csv(fp, index=False)
-        logger.info("Results saved to %s", fp)
+        log.info("Results saved to %s", fp)
         results.append(fp)
 
         monthly_work = wpa.analyze_monthly(df)
         if not monthly_work.empty:
             fp_m = out_dir / "work_pattern_monthly.csv"
             monthly_work.to_csv(fp_m, index=False)
-            logger.info("Results saved to %s", fp_m)
+            log.info("Results saved to %s", fp_m)
             results.append(fp_m)
     else:
         work_res = None
@@ -92,7 +92,7 @@ def main(argv: list[str] | None = None) -> list[Path]:
         attend_res = AttendanceBehaviorAnalyzer().analyze(df)
         fp = out_dir / "attendance.csv"
         attend_res.to_csv(fp, index=False)
-        logger.info("Results saved to %s", fp)
+        log.info("Results saved to %s", fp)
         results.append(fp)
     else:
         attend_res = None
@@ -101,7 +101,7 @@ def main(argv: list[str] | None = None) -> list[Path]:
         low_res = LowStaffLoadAnalyzer().analyze(df, threshold=args.threshold)
         fp = out_dir / "low_staff_load.csv"
         low_res.to_csv(fp, index=False)
-        logger.info("Results saved to %s", fp)
+        log.info("Results saved to %s", fp)
         results.append(fp)
 
     if args.analysis in ("score", "all"):
@@ -112,7 +112,7 @@ def main(argv: list[str] | None = None) -> list[Path]:
         )
         fp = out_dir / "combined_score.csv"
         score_res.to_csv(fp, index=False)
-        logger.info("Results saved to %s", fp)
+        log.info("Results saved to %s", fp)
         results.append(fp)
 
     return results

--- a/shift_suite/tasks/h2hire.py
+++ b/shift_suite/tasks/h2hire.py
@@ -32,7 +32,7 @@ def _calc_hire_fte(lack_h: float, monthly_hours_fte: int = MONTHLY_HOURS_FTE) ->
     return int(math.ceil(lack_h / monthly_hours_fte))
 
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 def build_hire_plan(
@@ -86,4 +86,4 @@ if __name__ == "__main__":  # CLI テスト用
     p.add_argument("out_dir", type=Path, help="解析 out フォルダ")
     args = p.parse_args()
     fp = build_hire_plan(args.out_dir)
-    logger.info("✅ hire_plan saved: %s", fp.relative_to(Path.cwd()))
+    log.info("✅ hire_plan saved: %s", fp.relative_to(Path.cwd()))


### PR DESCRIPTION
## Summary
- unify logger variable names to `log`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68410889a75c833395b0b54676df7761