### PR TITLE
Add shortage reason logging

### DIFF
--- a/shift_suite/resources/strings_ja.json
+++ b/shift_suite/resources/strings_ja.json
@@ -183,4 +183,18 @@
   "Max shortage": "最大不足発生日時",
   "Shortage by role caption": "各職種の不足時間を示します。値が大きい職種に注目してください。",
   "Shortage by time caption": "時間帯ごとの不足状況を示します。ピーク時間帯を確認してください。"
+  "Over/Short Log": "過不足日誌",
+  "Reason Category": "理由カテゴリ",
+  "Related Staff": "関連スタッフ",
+  "Memo": "メモ",
+  "Save log": "過不足日誌保存",
+  "Append": "追記",
+  "Overwrite": "上書き",
+  "Reason stats": "理由別過不足集計",
+  "Sudden absence": "急な欠勤（病欠等）",
+  "Planned leave": "予定休暇（有給・希望休）",
+  "Training/Meeting": "研修・会議",
+  "Resident response": "入居者対応（状態変化、緊急時）",
+  "Hiring delay": "採用遅延",
+  "Other": "その他",
 }

--- a/shift_suite/tasks/merge_shortage_leave.py
+++ b/shift_suite/tasks/merge_shortage_leave.py
@@ -11,6 +11,8 @@ def merge_shortage_leave(
     shortage_excel: str | Path = "shortage_time.xlsx",
     leave_csv: str | Path = "leave_analysis.csv",
     out_csv: str | Path = "shortage_leave.csv",
+    *,
+    log_csv: str | Path = "over_shortage_log.csv",
 ) -> Path:
     """Merge ``shortage_time.xlsx`` with ``leave_analysis.csv``.
 
@@ -58,6 +60,21 @@ def merge_shortage_leave(
     merged = lack_long.merge(leave_sum, on="date", how="left")
     merged["leave_applicants"] = merged["leave_applicants"].fillna(0)
     merged["net_shortage"] = (merged["lack"] - merged["leave_applicants"]).clip(lower=0)
+
+    log_fp = out_dir_path / log_csv
+    if log_fp.exists():
+        log_df = pd.read_csv(log_fp)
+        log_df = log_df[log_df.get("type") == "shortage"].copy()
+        if not log_df.empty:
+            log_df["date"] = pd.to_datetime(log_df["date"]).dt.date
+            other = (
+                log_df[log_df.get("reason") != "Planned leave"]
+                .groupby(["date", "time"])["count"]
+                .sum()
+                .reset_index(name="other_reason_lack")
+            )
+            merged = merged.merge(other, on=["date", "time"], how="left")
+            merged["other_reason_lack"] = merged["other_reason_lack"].fillna(0)
 
     out_fp = out_dir_path / out_csv
     merged.to_csv(out_fp, index=False)

--- a/shift_suite/tasks/over_shortage_log.py
+++ b/shift_suite/tasks/over_shortage_log.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+import pandas as pd
+
+
+def list_events(out_dir: Path | str) -> pd.DataFrame:
+    """Return shortage/excess events as a DataFrame."""
+    out_dir_path = Path(out_dir)
+    records = []
+
+    def _read(fp: Path, sheet: str, kind: str) -> None:
+        if fp.exists():
+            df = pd.read_excel(fp, sheet_name=sheet, index_col=0)
+            long = (
+                df.reset_index()
+                .melt(id_vars=df.index.name, var_name="date", value_name="count")
+                .rename(columns={df.index.name: "time"})
+            )
+            long["date"] = pd.to_datetime(long["date"]).dt.date
+            long = long[long["count"] > 0]
+            if not long.empty:
+                long["type"] = kind
+                records.append(long)
+
+    _read(out_dir_path / "shortage_time.xlsx", "lack_time", "shortage")
+    _read(out_dir_path / "excess_time.xlsx", "excess_time", "excess")
+
+    if records:
+        return pd.concat(records, ignore_index=True)
+    return pd.DataFrame(columns=["time", "date", "count", "type"])
+
+
+def load_log(csv_path: Path | str) -> pd.DataFrame:
+    csv_fp = Path(csv_path)
+    if csv_fp.exists():
+        return pd.read_csv(csv_fp)
+    return pd.DataFrame()
+
+
+def save_log(df: pd.DataFrame, csv_path: Path | str, *, mode: str = "overwrite") -> Path:
+    csv_fp = Path(csv_path)
+    if mode == "append" and csv_fp.exists():
+        existing = pd.read_csv(csv_fp)
+        df = pd.concat([existing, df], ignore_index=True)
+    df.to_csv(csv_fp, index=False)
+    return csv_fp
+


### PR DESCRIPTION
## Summary
- support recording shortage/excess reasons in app
- keep a CSV log with `over_shortage_log.py`
- merge log info into `shortage_leave.csv`
- expand Japanese strings
- test new merge behaviour

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68413265a17c8333987552c6b13fa0d0