### PR TITLE
Implement Markdown summary report generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -2624,6 +2624,35 @@ def display_hireplan_tab(tab_container, data_dir):
             st.info(_("Hiring Plan") + " (hire_plan.xlsx) " + _("が見つかりません。"))
 
 
+def display_summary_report_tab(tab_container, data_dir):
+    """Show auto-generated shortage summary report."""
+
+    with tab_container:
+        st.subheader(_("Summary Report"))
+        report_files = sorted(Path(data_dir).glob("OverShortage_SummaryReport_*.md"))
+        latest = report_files[-1] if report_files else None
+
+        if st.button(_("Generate Summary Report")):
+            try:
+                from shift_suite.tasks.report_generator import generate_summary_report
+
+                latest = generate_summary_report(Path(data_dir))
+                st.success(_("Report generated"))
+            except Exception as e:
+                log_and_display_error("summary report generation failed", e)
+
+        if latest and latest.exists():
+            md_text = latest.read_text(encoding="utf-8")
+            st.markdown(md_text)
+            with open(latest, "rb") as f:
+                st.download_button(
+                    label=_("Download Report (Markdown)"),
+                    data=f,
+                    file_name=latest.name,
+                    mime="text/markdown",
+                    use_container_width=True,
+                )
+
 def load_leave_results_from_dir(data_dir: Path) -> dict:
     """Wrapper for :func:`dashboard.load_leave_results_from_dir`."""
 
@@ -2915,6 +2944,7 @@ if st.session_state.get("analysis_done", False) and st.session_state.analysis_re
                 "Leave Analysis",
                 "Cost Sim",
                 "Hire Plan",
+                "Summary Report",
                 "PPT Report",
             ]
             tab_labels_dash = [_(key) for key in tab_keys_en_dash]
@@ -2929,6 +2959,7 @@ if st.session_state.get("analysis_done", False) and st.session_state.analysis_re
                 "Leave Analysis": display_leave_analysis_tab,
                 "Cost Sim": display_costsim_tab,
                 "Hire Plan": display_hireplan_tab,
+                "Summary Report": display_summary_report_tab,
                 "PPT Report": display_ppt_tab,
             }
             for i, key in enumerate(tab_keys_en_dash):
@@ -3011,6 +3042,7 @@ if zip_file_uploaded_dash_final_v3_display_main_dash:
         "Leave Analysis",
         "Cost Sim",
         "Hire Plan",
+        "Summary Report",
         "PPT Report",
     ]
     tab_labels_dash = [_(key) for key in tab_keys_en_dash]
@@ -3027,6 +3059,7 @@ if zip_file_uploaded_dash_final_v3_display_main_dash:
             "Leave Analysis": display_leave_analysis_tab,
             "Cost Sim": display_costsim_tab,
             "Hire Plan": display_hireplan_tab,
+            "Summary Report": display_summary_report_tab,
             "PPT Report": display_ppt_tab,
         }
 

--- a/shift_suite/resources/strings_ja.json
+++ b/shift_suite/resources/strings_ja.json
@@ -8,6 +8,7 @@
   "Cost Sim": "コスト試算",
   "Hire Plan": "採用計画",
   "PPT Report": "PPTレポート",
+  "Summary Report": "サマリーレポート",
   "Leave Analysis": "休暇分析",
   "Alerts": "アラート",
   "Slot (min)": "スロット (分)",

--- a/shift_suite/tasks/report_generator.py
+++ b/shift_suite/tasks/report_generator.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from pathlib import Path
+from datetime import datetime
+import pandas as pd
+
+
+def _read_excel(fp: Path, sheet: str) -> pd.DataFrame:
+    if fp.exists():
+        try:
+            return pd.read_excel(fp, sheet_name=sheet)
+        except Exception:
+            return pd.DataFrame()
+    return pd.DataFrame()
+
+
+def generate_summary_report(out_dir: Path | str) -> Path:
+    """Generate Markdown shortage summary report under *out_dir*.
+
+    Parameters
+    ----------
+    out_dir : Path | str
+        Directory containing analysis Excel outputs.
+
+    Returns
+    -------
+    Path
+        Path to the created Markdown report.
+    """
+    out_dir_path = Path(out_dir)
+    out_dir_path.mkdir(parents=True, exist_ok=True)
+
+    role_fp = out_dir_path / "shortage_role.xlsx"
+    stats_fp = out_dir_path / "stats.xlsx"
+    weekday_fp = out_dir_path / "shortage_weekday_timeslot_summary.xlsx"
+    heat_fp = out_dir_path / "heat_ALL.xlsx"
+
+    role_df = _read_excel(role_fp, "role_summary")
+
+    if stats_fp.exists():
+        try:
+            xls = pd.ExcelFile(stats_fp)
+            _ = xls.parse("Overall_Summary") if "Overall_Summary" in xls.sheet_names else pd.DataFrame()
+            monthly_df = xls.parse("Monthly_Summary") if "Monthly_Summary" in xls.sheet_names else pd.DataFrame()
+            alerts_df = xls.parse("alerts") if "alerts" in xls.sheet_names else pd.DataFrame()
+        except Exception:
+            monthly_df = alerts_df = pd.DataFrame()
+    else:
+        monthly_df = alerts_df = pd.DataFrame()
+
+    weekday_df = pd.DataFrame()
+    if weekday_fp.exists():
+        try:
+            weekday_df = pd.read_excel(weekday_fp)
+        except Exception:
+            weekday_df = pd.DataFrame()
+
+    min_date = max_date = ""
+    if heat_fp.exists():
+        try:
+            heat_df = pd.read_excel(heat_fp, index_col=0)
+            date_cols = pd.to_datetime(heat_df.columns, errors="coerce").dropna()
+            if not date_cols.empty:
+                min_date = date_cols.min().date().isoformat()
+                max_date = date_cols.max().date().isoformat()
+        except Exception:
+            pass
+
+    lack_h_total = float(role_df.get("lack_h", pd.Series()).sum())
+    excess_h_total = float(role_df.get("excess_h", pd.Series()).sum())
+    lack_cost_total = float(role_df.get("estimated_lack_cost_if_temporary_staff", pd.Series()).sum())
+    penalty_cost_total = float(role_df.get("estimated_lack_penalty_cost", pd.Series()).sum())
+    excess_cost_total = float(role_df.get("estimated_excess_cost", pd.Series()).sum())
+
+    top_lack_roles = []
+    if {"role", "lack_h"}.issubset(role_df.columns):
+        top_lack_roles = role_df.nlargest(3, "lack_h")[["role", "lack_h"]]
+
+    top_excess_roles = []
+    if {"role", "excess_h"}.issubset(role_df.columns):
+        top_excess_roles = role_df.nlargest(3, "excess_h")[["role", "excess_h"]]
+
+    trend_txt = ""
+    if not monthly_df.empty and {"month", "summary_item"}.issubset(monthly_df.columns):
+        hour_col = next((c for c in monthly_df.columns if "(hours)" in c), None)
+        if hour_col:
+            df_lack = monthly_df[monthly_df["summary_item"] == "lack"].copy()
+            if not df_lack.empty:
+                df_lack["month_dt"] = pd.to_datetime(df_lack["month"], errors="coerce")
+                df_lack = df_lack.dropna(subset=["month_dt"]).sort_values("month_dt")
+                if len(df_lack) >= 2:
+                    first = float(df_lack.iloc[0][hour_col])
+                    last = float(df_lack.iloc[-1][hour_col])
+                    if first:
+                        pct = (last - first) / first * 100
+                        trend_txt = f"過去{len(df_lack)}ヶ月で不足時間は{pct:+.1f}%変化しています"
+
+    timeslot_lines = []
+    if not weekday_df.empty:
+        num_col = next((c for c in weekday_df.columns if pd.api.types.is_numeric_dtype(weekday_df[c])), None)
+        if num_col and {"weekday", "timeslot"}.issubset(weekday_df.columns):
+            top_ts = weekday_df.nlargest(3, num_col)
+            for _, row in top_ts.iterrows():
+                timeslot_lines.append(f"{row['weekday']}{row['timeslot']} 平均{row[num_col]:.1f}人不足")
+
+    alert_lines = []
+    if not alerts_df.empty:
+        col = alerts_df.columns[0]
+        alert_lines = [f"- {v}" for v in alerts_df[col].astype(str).head(5)]
+
+    today = datetime.now().strftime("%Y年%m月%d日")
+    title = f"### 過不足分析サマリーレポート ({today}作成)"
+
+    md_lines = [title]
+    if min_date and max_date:
+        md_lines.append(f"**分析期間**: {min_date} ～ {max_date}")
+    md_lines.append("\n#### 総括")
+    md_lines.append(f"- 総不足時間: {lack_h_total:.1f}h (派遣補填想定 {lack_cost_total:,.0f}円, ペナルティ {penalty_cost_total:,.0f}円)")
+    md_lines.append(f"- 総過剰時間: {excess_h_total:.1f}h (コスト {excess_cost_total:,.0f}円)")
+
+    if len(top_lack_roles) > 0:
+        md_lines.append("- 最も不足の多い職種トップ3:")
+        for _, r in top_lack_roles.iterrows():
+            md_lines.append(f"  - {r['role']}: {r['lack_h']:.1f}h")
+    if len(top_excess_roles) > 0:
+        md_lines.append("- 最も過剰の多い職種トップ3:")
+        for _, r in top_excess_roles.iterrows():
+            md_lines.append(f"  - {r['role']}: {r['excess_h']:.1f}h")
+
+    if trend_txt or timeslot_lines:
+        md_lines.append("\n#### 傾向分析")
+        if trend_txt:
+            md_lines.append(f"- {trend_txt}")
+        if timeslot_lines:
+            md_lines.append("- 不足が集中している曜日・時間帯トップ3:")
+            md_lines.extend([f"  - {t}" for t in timeslot_lines])
+
+    if alert_lines:
+        md_lines.append("\n#### 主要アラート")
+        md_lines.extend(alert_lines)
+
+    md_lines.append("\n#### 推奨アクションのヒント")
+    if not top_lack_roles.empty:
+        md_lines.append("- 特定職種の不足が顕著です。採用強化や配置見直しをご検討ください。")
+    if timeslot_lines:
+        md_lines.append("- 特定の曜日・時間帯で不足が多発しています。シフト調整をご検討ください。")
+
+    markdown_text = "\n".join(md_lines) + "\n"
+
+    out_fp = out_dir_path / f"OverShortage_SummaryReport_{datetime.now().strftime('%Y%m%d')}.md"
+    out_fp.write_text(markdown_text, encoding="utf-8")
+    return out_fp

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -1,0 +1,51 @@
+import pandas as pd
+from pathlib import Path
+from shift_suite.tasks.report_generator import generate_summary_report
+
+
+def _create_sample_files(out_dir: Path) -> None:
+    # heat_ALL.xlsx for date range detection
+    heat_df = pd.DataFrame({"2024-06-01": [1], "2024-07-01": [2]})
+    heat_df.to_excel(out_dir / "heat_ALL.xlsx")
+
+    role_df = pd.DataFrame(
+        {
+            "role": ["A", "B"],
+            "lack_h": [5.0, 2.0],
+            "excess_h": [1.0, 0.0],
+            "estimated_lack_cost_if_temporary_staff": [5000, 2000],
+            "estimated_lack_penalty_cost": [10000, 4000],
+            "estimated_excess_cost": [1000, 0],
+        }
+    )
+    role_df.to_excel(out_dir / "shortage_role.xlsx", sheet_name="role_summary", index=False)
+
+    emp_df = pd.DataFrame({"employment": ["FT"], "lack_h": [3]})
+    emp_df.to_excel(out_dir / "shortage_employment.xlsx", sheet_name="employment_summary", index=False)
+
+    overall_df = pd.DataFrame({"summary_item": ["lack", "excess"], "value": [7, 3]})
+    monthly_df = pd.DataFrame(
+        {
+            "month": ["2024-06", "2024-07"],
+            "summary_item": ["lack", "lack"],
+            "total_value_period (hours)": [10, 12],
+        }
+    )
+    alerts_df = pd.DataFrame({"alert": ["check A", "check B"]})
+    with pd.ExcelWriter(out_dir / "stats.xlsx") as writer:
+        overall_df.to_excel(writer, sheet_name="Overall_Summary", index=False)
+        monthly_df.to_excel(writer, sheet_name="Monthly_Summary", index=False)
+        alerts_df.to_excel(writer, sheet_name="alerts", index=False)
+
+    wd_df = pd.DataFrame(
+        {"weekday": ["Mon", "Tue"], "timeslot": ["09:00", "10:00"], "lack": [3, 1]}
+    )
+    wd_df.to_excel(out_dir / "shortage_weekday_timeslot_summary.xlsx", index=False)
+
+
+def test_generate_summary_report(tmp_path: Path) -> None:
+    _create_sample_files(tmp_path)
+    md_path = generate_summary_report(tmp_path)
+    assert md_path.exists()
+    text = md_path.read_text(encoding="utf-8")
+    assert "総不足時間" in text


### PR DESCRIPTION
## Summary
- add `generate_summary_report` utility for shortage overview
- expose report in Streamlit UI via new Summary Report tab
- provide Japanese label for new tab
- test summary report generation

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas and others)*

------
https://chatgpt.com/codex/tasks/task_e_684138bf199c8333abf52758b0e02849