### PR TITLE
Fix nested expander comment

### DIFF
--- a/app.py
+++ b/app.py
@@ -554,6 +554,8 @@ with st.sidebar:
         )
 
         if _("Leave Analysis") in st.session_state.ext_opts_multiselect_widget:
+            # Nested expanders trigger StreamlitAPIException, so use a heading
+            # instead of an inner st.expander here.
             st.markdown("### 📊 " + _("Leave Analysis") + " 設定")
             st.multiselect(
                 "分析対象の休暇タイプ",


### PR DESCRIPTION
## Summary
- add comment clarifying that nested expanders are avoided

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684142febbf8833387a34b38ba6ee967