### PR TITLE
Fix: document Streamlit nested expander issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,3 +287,7 @@ Runtime settings and translation strings are stored in separate files under
 
 Modify these files to tweak behaviour or update translations without touching
 the Python source.
+
+### Troubleshooting
+
+When launching the GUI, Streamlit will raise `StreamlitAPIException: Expanders may not be nested inside other expanders` if an `st.expander` is created within another expander.  The code avoids this by replacing the inner expander for **Leave Analysis** with a simple Markdown heading.  If you encounter this error, check that your local copy reflects this structure or remove the nested expander.


### PR DESCRIPTION
## Summary
- clarify troubleshooting steps for `StreamlitAPIException` when expanders are nested

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6841454c0e388333be2aee3270e0fee2