### PR TITLE
Fix wizard ordering and translations

### DIFF
--- a/app.py
+++ b/app.py
@@ -410,6 +410,8 @@ if "app_initialized" not in st.session_state:
     st.session_state.wizard_mapping = {}
     log.info("セッションステートを初期化しました。")
 
+run_import_wizard()
+
 # --- サイドバーのUI要素 ---
 with st.sidebar:
     st.header("🛠️ 解析設定")
@@ -424,37 +426,42 @@ with st.sidebar:
         )
 
     with st.expander("📄 シート選択とヘッダー", expanded=True):
-        if st.session_state.get("_force_update_multiselect_flag", False):
-            new_options = st.session_state.candidate_sheet_list_for_ui
-            current_selection = st.session_state.get("shift_sheets_multiselect_widget", [])
-            valid_selection = [s for s in current_selection if s in new_options]
-            if not valid_selection and new_options:
-                st.session_state.shift_sheets_multiselect_widget = new_options[:]
-            elif valid_selection:
-                st.session_state.shift_sheets_multiselect_widget = valid_selection
-            else:
-                st.session_state.shift_sheets_multiselect_widget = []
-            st.session_state._force_update_multiselect_flag = False
+        if st.session_state.get("wizard_step", 1) <= 2:
+            st.info("Use the Excel Import Wizard to select sheets")
+        else:
+            if st.session_state.get("_force_update_multiselect_flag", False):
+                new_options = st.session_state.candidate_sheet_list_for_ui
+                current_selection = st.session_state.get(
+                    "shift_sheets_multiselect_widget", []
+                )
+                valid_selection = [s for s in current_selection if s in new_options]
+                if not valid_selection and new_options:
+                    st.session_state.shift_sheets_multiselect_widget = new_options[:]
+                elif valid_selection:
+                    st.session_state.shift_sheets_multiselect_widget = valid_selection
+                else:
+                    st.session_state.shift_sheets_multiselect_widget = []
+                st.session_state._force_update_multiselect_flag = False
 
-        st.multiselect(
-            _("Select shift sheets to analyze (multiple)"),
-            options=st.session_state.candidate_sheet_list_for_ui,
-            default=st.session_state.shift_sheets_multiselect_widget,
-            key="shift_sheets_multiselect_widget",
-            help="解析対象とするシートを選択します。",
-        )
-        st.number_input(
-            _("Header row number (1-indexed)"),
-            1,
-            20,
-            key="header_row_input_widget",
-            help="スクリーンショット例の 'No' など列名がある行番号",
-        )
-        st.text_input(
-            _("Year-Month cell location"),
-            key="year_month_cell_input_widget",
-            help="年月情報が記載されているセル位置 (例: A1)",
-        )
+            st.multiselect(
+                _("Select shift sheets to analyze (multiple)"),
+                options=st.session_state.candidate_sheet_list_for_ui,
+                default=st.session_state.shift_sheets_multiselect_widget,
+                key="shift_sheets_multiselect_widget",
+                help="解析対象とするシートを選択します。",
+            )
+            st.number_input(
+                _("Header row number (1-indexed)"),
+                1,
+                20,
+                key="header_row_input_widget",
+                help="スクリーンショット例の 'No' など列名がある行番号",
+            )
+            st.text_input(
+                _("Year-Month cell location"),
+                key="year_month_cell_input_widget",
+                help="年月情報が記載されているセル位置 (例: A1)",
+            )
 
     with st.expander(_("Need Calculation Settings (Day of Week Pattern)")):
         if st.session_state.get("_force_update_need_ref_dates_flag", False):
@@ -630,7 +637,6 @@ with st.sidebar:
         )
 
 # --- メインコンテンツエリア ---
-run_import_wizard()
 holiday_file_global_uploaded = st.file_uploader(
     _("Global holiday file (CSV or JSON)"),
     type=["csv", "json"],

--- a/shift_suite/resources/strings_ja.json
+++ b/shift_suite/resources/strings_ja.json
@@ -183,7 +183,7 @@
   "Top shortage role {n}": "不足職種トップ{n}",
   "Max shortage": "最大不足発生日時",
   "Shortage by role caption": "各職種の不足時間を示します。値が大きい職種に注目してください。",
-  "Shortage by time caption": "時間帯ごとの不足状況を示します。ピーク時間帯を確認してください。"
+  "Shortage by time caption": "時間帯ごとの不足状況を示します。ピーク時間帯を確認してください。",
   "Over/Short Log": "過不足日誌",
   "Reason Category": "理由カテゴリ",
   "Related Staff": "関連スタッフ",
@@ -202,5 +202,6 @@
   "Train factor model": "要因分析モデルを学習",
   "Select date for factor analysis": "要因分析対象日付を選択",
   "Select time slot for factor analysis": "要因分析対象時間帯を選択",
-  "Top factors": "主要因トップ"
+  "Top factors": "主要因トップ",
+  "Use the Excel Import Wizard to select sheets": "Excel インポートウィザードでシートを選択してください"
 }


### PR DESCRIPTION
## Summary
- load the Excel Import Wizard before sidebar widgets
- show a message in the sidebar while wizard is active
- add translation for wizard message and fix JSON syntax

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6841474ebc0c83338c1b020d52b64063