### PR TITLE
Fix session state default for extra modules

### DIFF
--- a/app.py
+++ b/app.py
@@ -552,6 +552,11 @@ with st.sidebar:
 
     st.divider()
     with st.expander("追加分析モジュール"):
+        if "ext_opts_multiselect_widget" not in st.session_state:
+            st.session_state.ext_opts_multiselect_widget = (
+                st.session_state.get("available_ext_opts_widget", [])
+            )
+
         st.multiselect(
             _("Extra modules"),
             st.session_state.available_ext_opts_widget,


### PR DESCRIPTION
## Summary
- ensure `ext_opts_multiselect_widget` is initialized before use

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684158cc23d88333b5e13e4389d09897