### PR TITLE
Fix session state key error in import wizard

### DIFF
--- a/app.py
+++ b/app.py
@@ -212,7 +212,9 @@ def run_import_wizard() -> None:
 
     if step == 3:
         first = st.session_state.shift_sheets_multiselect_widget[0]
-        hdr = st.session_state[f"hdr_{first}"]
+        hdr = st.session_state.get(
+            f"hdr_{first}", st.session_state.get("header_row_input_widget", 2)
+        )
         df_cols = pd.read_excel(
             st.session_state.wizard_excel_path,
             sheet_name=first,


### PR DESCRIPTION
## Summary
- avoid `KeyError` for missing hdr_* session state in wizard

## Testing
- `ruff check .`
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68415a0f2cb48333a61c04831aa067a7