### PR TITLE
Fix year-month cell reading when Excel stores a date

### DIFF
--- a/shift_suite/tasks/io_excel.py
+++ b/shift_suite/tasks/io_excel.py
@@ -267,9 +267,18 @@ def ingest_excel(
             ym_raw = str(ym_df.iloc[0, 0])
             log.debug(f"読み込んだ年月セルの生データ: '{ym_raw}'")
             m = re.search(r"(\d{4})年(\d{1,2})月", ym_raw)
-            if not m:
-                raise ValueError(f"'{ym_raw}' does not match YYYY年MM月 format")
-            year_val, month_val = int(m.group(1)), int(m.group(2))
+            if m:
+                year_val, month_val = int(m.group(1)), int(m.group(2))
+            else:
+                try:
+                    ym_dt = pd.to_datetime(ym_raw)
+                    if pd.isna(ym_dt):
+                        raise ValueError
+                    year_val, month_val = ym_dt.year, ym_dt.month
+                except Exception:
+                    raise ValueError(
+                        f"'{ym_raw}' does not match YYYY年MM月 format"
+                    ) from None
             log.info(f"解析結果: 年={year_val}, 月={month_val}")
         except Exception as e:
             log.error(f"年月セル '{year_month_cell_location}' の読み込み失敗: {e}")

--- a/tests/test_io_excel_yearmonth.py
+++ b/tests/test_io_excel_yearmonth.py
@@ -5,7 +5,7 @@ import pytest
 from shift_suite.tasks.io_excel import ingest_excel
 
 
-def _create_excel(path: Path, ym_cell_value: str | None = "2023年10月") -> None:
+def _create_excel(path: Path, ym_cell_value: object | None = "2023年10月") -> None:
     wb = Workbook()
     ws = wb.active
     ws.title = "Sheet1"
@@ -44,3 +44,17 @@ def test_ingest_excel_year_month_missing(tmp_path: Path) -> None:
             slot_minutes=30,
             year_month_cell_location="A1",
         )
+
+
+def test_ingest_excel_with_date_in_year_month_cell(tmp_path: Path) -> None:
+    fp = tmp_path / "shift.xlsx"
+    _create_excel(fp, ym_cell_value=dt.date(2025, 2, 1))
+    long_df, _ = ingest_excel(
+        fp,
+        shift_sheets=["Sheet1"],
+        header_row=2,
+        slot_minutes=30,
+        year_month_cell_location="A1",
+    )
+    dates = sorted({d.date() for d in long_df["ds"]})
+    assert dates == [dt.date(2025, 2, 1), dt.date(2025, 2, 2)]


### PR DESCRIPTION
## Summary
- support reading Excel year/month cells that hold datetime values
- allow tests to pass a non-string value to `_create_excel`
- test ingesting Excel with a datetime in the year/month cell

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684166912b3c83338a2182274dd1e5aa