### PR TITLE
Improve ingest logging and warnings

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -73,12 +73,14 @@ def main():
     xls = pd.ExcelFile(excel)
     shift_sheets = [s for s in xls.sheet_names if "勤務区分" not in s]
 
-    long, _ = ingest_excel(
+    long, _, unknown_codes = ingest_excel(
         excel,
         shift_sheets=shift_sheets,
         header_row=args.header,
         slot_minutes=args.slot,
     )
+    if unknown_codes:
+        log.warning("Unknown shift codes found: %s", sorted(unknown_codes))
 
     ref_start = pd.to_datetime(long["ds"]).dt.date.min()
     ref_end = pd.to_datetime(long["ds"]).dt.date.max()

--- a/tests/test_ingest_employment.py
+++ b/tests/test_ingest_employment.py
@@ -19,6 +19,7 @@ def test_ingest_excel_employment(tmp_path: Path):
         wt.to_excel(writer, sheet_name="勤務区分", index=False)
         df.to_excel(writer, sheet_name="Sheet1", index=False)
 
-    long_df, _ = ingest_excel(excel_fp, shift_sheets=["Sheet1"], header_row=1)
+    long_df, _, unknown = ingest_excel(excel_fp, shift_sheets=["Sheet1"], header_row=1)
+    assert not unknown
     assert "employment" in long_df.columns
     assert set(long_df["employment"]) == {"正社員"}

--- a/tests/test_io_excel_yearmonth.py
+++ b/tests/test_io_excel_yearmonth.py
@@ -22,13 +22,14 @@ def _create_excel(path: Path, ym_cell_value: object | None = "2023年10月") -> 
 def test_ingest_excel_with_year_month(tmp_path: Path) -> None:
     fp = tmp_path / "shift.xlsx"
     _create_excel(fp)
-    long_df, _ = ingest_excel(
+    long_df, _, unknown = ingest_excel(
         fp,
         shift_sheets=["Sheet1"],
         header_row=2,
         slot_minutes=30,
         year_month_cell_location="A1",
     )
+    assert not unknown
     dates = sorted({d.date() for d in long_df["ds"]})
     assert dates == [dt.date(2023, 10, 1), dt.date(2023, 10, 2)]
 
@@ -49,12 +50,13 @@ def test_ingest_excel_year_month_missing(tmp_path: Path) -> None:
 def test_ingest_excel_with_date_in_year_month_cell(tmp_path: Path) -> None:
     fp = tmp_path / "shift.xlsx"
     _create_excel(fp, ym_cell_value=dt.date(2025, 2, 1))
-    long_df, _ = ingest_excel(
+    long_df, _, unknown = ingest_excel(
         fp,
         shift_sheets=["Sheet1"],
         header_row=2,
         slot_minutes=30,
         year_month_cell_location="A1",
     )
+    assert not unknown
     dates = sorted({d.date() for d in long_df["ds"]})
     assert dates == [dt.date(2025, 2, 1), dt.date(2025, 2, 2)]


### PR DESCRIPTION
## Summary
- surface unknown shift codes in GUI and CLI
- log result object types when opening analysis tabs
- return unknown codes from ingest_excel
- adjust tests for new return value

## Testing
- `ruff check .`
- `pytest -q` *(fails: pandas installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68417108208c83339a6b77b8ab7b1d9e