### PR TITLE
Fix DataFrame preview cast to str

### DIFF
--- a/app.py
+++ b/app.py
@@ -720,7 +720,7 @@ if (
             _("Preview")
             + f": {st.session_state.shift_sheets_multiselect_widget[0]} (first 5 rows)"
         )
-        st.dataframe(preview_df_sidebar, use_container_width=True)
+        st.dataframe(preview_df_sidebar.astype(str), use_container_width=True)
     except Exception as e_prev:
         st.warning(_("Error during preview display") + f": {e_prev}")
 


### PR DESCRIPTION
## Summary
- avoid Arrow conversion errors when previewing upload by casting preview DataFrame to string

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684173c9fa208333bc55040cbaed0ec3