### PR TITLE
Improve logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -87,6 +87,27 @@ configure_logging()
 log = logging.getLogger(__name__)
 
 
+def log_environment_info() -> None:
+    """Log basic environment details to help with debugging."""
+    import os
+    import platform
+    import sys
+    log.info("Python: %s", sys.version.replace("\n", " "))
+    log.info("Platform: %s", platform.platform())
+    log.info("Working dir: %s", Path.cwd())
+    log.info("Streamlit: %s", st.__version__)
+    try:
+        import torch
+
+        log.info("PyTorch: %s", torch.__version__)
+    except Exception as e:  # pragma: no cover - optional
+        log.info("PyTorch not available: %s", e)
+    log.debug("Environment PATH: %s", os.getenv("PATH", ""))
+
+
+log_environment_info()
+
+
 # ── Utility: log error to terminal and show in Streamlit ──
 def log_and_display_error(msg: str, exc: Exception) -> None:
     """Log an error and also show it in the Streamlit interface."""

--- a/shift_suite/logger_config.py
+++ b/shift_suite/logger_config.py
@@ -1,11 +1,24 @@
 import logging
+import os
 import sys
 
 
 def configure_logging(level: int = logging.INFO) -> None:
-    """Configure root logger with a unified format if not already configured."""
+    """Configure root logger.
+
+    The log level can be overridden by the ``SHIFT_SUITE_LOG_LEVEL``
+    environment variable.  Values may be numeric (e.g. ``10``) or one of
+    the standard logging level names such as ``DEBUG`` or ``INFO``.
+    """
     if logging.getLogger().hasHandlers():
         return
+
+    env_level = os.getenv("SHIFT_SUITE_LOG_LEVEL")
+    if env_level:
+        if env_level.isdigit():
+            level = int(env_level)
+        else:
+            level = getattr(logging, env_level.upper(), level)
 
     handler = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter(


### PR DESCRIPTION
## Summary
- allow overriding log level via `SHIFT_SUITE_LOG_LEVEL`
- emit environment details when launching `app.py`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6841790d014c83338409deef2569a8b0