### PR TITLE
Fix streamlit watcher patch

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,6 +89,9 @@ def _patch_streamlit_watcher() -> None:
     except Exception:
         return
 
+    if not hasattr(_lsw, "extract_paths"):
+        return
+
     if getattr(_lsw.extract_paths, "_patched", False):
         return
 


### PR DESCRIPTION
## Summary
- avoid attribute error when streamlit local_sources_watcher lacks `extract_paths`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68417c6ed24c833382eaf649ba431dd0