### PR TITLE
Improve error logging when exception object is missing

### DIFF
--- a/app.py
+++ b/app.py
@@ -139,10 +139,24 @@ log_environment_info()
 
 
 # ── Utility: log error to terminal and show in Streamlit ──
-def log_and_display_error(msg: str, exc: Exception) -> None:
-    """Log an error and also show it in the Streamlit interface."""
-    log.error(f"{msg}: {exc}", exc_info=True)
-    st.error(f"{msg}: {exc}")
+def log_and_display_error(msg: str, exc: Exception | None) -> None:
+    """Log an error and also show it in the Streamlit interface.
+
+    Parameters
+    ----------
+    msg : str
+        User-facing error message.
+    exc : Exception | None
+        Exception instance, if available. ``None`` is allowed to avoid
+        displaying ``NoneType: None`` when an exception object is absent.
+    """
+
+    if exc is not None:
+        log.error(f"{msg}: {exc}", exc_info=True)
+        st.error(f"{msg}: {exc}")
+    else:
+        log.error(msg)
+        st.error(msg)
 
 
 def log_and_display_error_enhanced(step: str, msg: str, exc: Exception) -> None:


### PR DESCRIPTION
## Summary
- handle `None` exception in `log_and_display_error` to avoid `NoneType: None`

## Testing
- `ruff check .`
- `pytest -q` *(fails: 21 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_684187d69fe8833395ace7b4bc7de481