### PR TITLE
Pin torch to CPU build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,8 @@ lightgbm==4.3.0
 prophet==1.1.6         # ★ Python 3.12 で動作する最新版
 stable-baselines3>=2.3
 gymnasium>=0.29        # ★ 明示
-torch>=2.3             # ★ CPU/GPU どちらでも可
+# 固定した CPU 版 PyTorch を使用する
+torch==2.3.1+cpu
 
 # ─── misc / utils ───
 python-pptx>=0.6


### PR DESCRIPTION
## Summary
- pin torch to a specific CPU version in requirements

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68418c17f3bc8333b3348c682605f024