### PR TITLE
Clean up imports with ruff

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,11 +1,13 @@
 """cli.py – コマンドライン一括実行"""
 
 import argparse
+import logging
 import shutil
 from pathlib import Path
-import logging
+
 import pandas as pd
-from shift_suite import ingest_excel, build_heatmap, shortage_and_brief, summary
+
+from shift_suite import build_heatmap, ingest_excel, shortage_and_brief, summary
 from shift_suite.h2hire import build_hire_plan as build_hire_plan_from_shortage
 from shift_suite.tasks.cost_benefit import analyze_cost_benefit
 from shift_suite.utils import safe_make_archive

--- a/dash_app.py
+++ b/dash_app.py
@@ -9,16 +9,18 @@ v2025-05-16 (カラースキーム変更)
 """
 
 from __future__ import annotations
+
+import logging
 import pathlib
 
 import dash
+import numpy as np  # ★ 追加: np.nan のため
 import pandas as pd
 import plotly.express as px
-from dash import dcc, html, Input, Output, callback
-import numpy as np  # ★ 追加: np.nan のため
-import logging
-from shift_suite.tasks.constants import SUMMARY5 as SUMMARY5_CONST
+from dash import Input, Output, callback, dcc, html
+
 from shift_suite.i18n import translate as _
+from shift_suite.tasks.constants import SUMMARY5 as SUMMARY5_CONST
 from shift_suite.tasks.dashboard import load_leave_results_from_dir
 
 # --- 日本語ラベル辞書は resources/strings_ja.json で管理 ---

--- a/tests/test_app_display_tabs.py
+++ b/tests/test_app_display_tabs.py
@@ -1,5 +1,7 @@
 import types
+
 import pandas as pd
+
 from shift_suite import app
 
 

--- a/tests/test_dashboard_visuals.py
+++ b/tests/test_dashboard_visuals.py
@@ -1,4 +1,5 @@
 import pandas as pd
+
 from shift_suite.tasks import dashboard
 
 

--- a/tests/test_excess_analysis.py
+++ b/tests/test_excess_analysis.py
@@ -1,5 +1,7 @@
-import pandas as pd
 from pathlib import Path
+
+import pandas as pd
+
 from shift_suite.tasks.shortage import shortage_and_brief
 from shift_suite.tasks.utils import gen_labels
 

--- a/tests/test_file_upload_no_exception.py
+++ b/tests/test_file_upload_no_exception.py
@@ -1,6 +1,8 @@
-import pandas as pd
 from pathlib import Path
+
+import pandas as pd
 import pytest
+
 import app
 
 

--- a/tests/test_forecast_need.py
+++ b/tests/test_forecast_need.py
@@ -1,6 +1,8 @@
 import types
-import pandas as pd
+
 import numpy as np
+import pandas as pd
+
 from shift_suite.tasks import forecast
 from shift_suite.tasks.forecast import forecast_need
 

--- a/tests/test_h2hire.py
+++ b/tests/test_h2hire.py
@@ -1,5 +1,7 @@
-import pandas as pd
 from pathlib import Path
+
+import pandas as pd
+
 from shift_suite.tasks.h2hire import build_hire_plan
 
 

--- a/tests/test_ingest_employment.py
+++ b/tests/test_ingest_employment.py
@@ -1,5 +1,7 @@
-import pandas as pd
 from pathlib import Path
+
+import pandas as pd
+
 from shift_suite.tasks.io_excel import ingest_excel
 
 

--- a/tests/test_io_excel_yearmonth.py
+++ b/tests/test_io_excel_yearmonth.py
@@ -1,7 +1,9 @@
 import datetime as dt
 from pathlib import Path
-from openpyxl import Workbook
+
 import pytest
+from openpyxl import Workbook
+
 from shift_suite.tasks.io_excel import ingest_excel
 
 

--- a/tests/test_learn_roster.py
+++ b/tests/test_learn_roster.py
@@ -1,5 +1,6 @@
 import sys
 import types
+
 import numpy as np
 import pandas as pd
 

--- a/tests/test_leave_concentration.py
+++ b/tests/test_leave_concentration.py
@@ -1,11 +1,12 @@
 import pandas as pd
+
 from shift_suite.tasks.leave_analyzer import (
-    analyze_leave_concentration,
+    LEAVE_TYPE_PAID,
+    LEAVE_TYPE_REQUESTED,
     analyze_both_leave_concentration,
+    analyze_leave_concentration,
     staff_concentration_share,
     summarize_leave_by_day_count,
-    LEAVE_TYPE_REQUESTED,
-    LEAVE_TYPE_PAID,
 )
 
 

--- a/tests/test_leave_summary.py
+++ b/tests/test_leave_summary.py
@@ -1,9 +1,10 @@
 import pandas as pd
+
 from shift_suite.tasks.leave_analyzer import (
-    summarize_leave_by_day_count,
-    leave_ratio_by_period_and_weekday,
-    LEAVE_TYPE_REQUESTED,
     LEAVE_TYPE_PAID,
+    LEAVE_TYPE_REQUESTED,
+    leave_ratio_by_period_and_weekday,
+    summarize_leave_by_day_count,
 )
 
 

--- a/tests/test_load_excel_cached.py
+++ b/tests/test_load_excel_cached.py
@@ -1,5 +1,7 @@
-import pandas as pd
 from pathlib import Path
+
+import pandas as pd
+
 from app import load_excel_cached
 
 

--- a/tests/test_load_excelfile_cached.py
+++ b/tests/test_load_excelfile_cached.py
@@ -1,5 +1,7 @@
-import pandas as pd
 from pathlib import Path
+
+import pandas as pd
+
 from app import load_excelfile_cached
 
 

--- a/tests/test_merge_shortage_leave.py
+++ b/tests/test_merge_shortage_leave.py
@@ -1,5 +1,7 @@
-import pandas as pd
 from pathlib import Path
+
+import pandas as pd
+
 from shift_suite.tasks.merge_shortage_leave import merge_shortage_leave
 
 

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -1,5 +1,7 @@
-import pandas as pd
 from pathlib import Path
+
+import pandas as pd
+
 from shift_suite.tasks.report_generator import generate_summary_report
 
 

--- a/tests/test_rl.py
+++ b/tests/test_rl.py
@@ -1,5 +1,6 @@
-import pandas as pd
 import numpy as np
+import pandas as pd
+
 from shift_suite.tasks import rl
 
 

--- a/tests/test_shortage_employment.py
+++ b/tests/test_shortage_employment.py
@@ -1,5 +1,7 @@
-import pandas as pd
 from pathlib import Path
+
+import pandas as pd
+
 from shift_suite.tasks.shortage import shortage_and_brief
 from shift_suite.tasks.utils import gen_labels
 

--- a/tests/test_shortage_factor_analyzer.py
+++ b/tests/test_shortage_factor_analyzer.py
@@ -1,4 +1,5 @@
 import pandas as pd
+
 from shift_suite.tasks.shortage_factor_analyzer import ShortageFactorAnalyzer
 
 

--- a/tests/test_shortage_slider.py
+++ b/tests/test_shortage_slider.py
@@ -1,5 +1,7 @@
-import pandas as pd
 from pathlib import Path
+
+import pandas as pd
+
 from shift_suite.tasks.shortage import shortage_and_brief
 from shift_suite.tasks.utils import gen_labels
 

--- a/tests/test_utils_basic.py
+++ b/tests/test_utils_basic.py
@@ -1,7 +1,7 @@
+import datetime as dt
 import importlib
 import sys
 import types
-import datetime as dt
 
 # Provide minimal pandas/numpy stubs so the module can be imported without the real dependencies
 fake_pd = types.SimpleNamespace(

--- a/tests/test_zip_leave_upload.py
+++ b/tests/test_zip_leave_upload.py
@@ -1,5 +1,7 @@
-import pandas as pd
 from pathlib import Path
+
+import pandas as pd
+
 import app
 
 


### PR DESCRIPTION
## Summary
- sort imports across project using `ruff`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68418cb751908333a9e83c0fafc64c21