### PR TITLE
Improve Excel reading error handling

### DIFF
--- a/shift_suite/tasks/report_generator.py
+++ b/shift_suite/tasks/report_generator.py
@@ -5,13 +5,17 @@ from pathlib import Path
 
 import pandas as pd
 
+from .utils import log, safe_read_excel
+
 
 def _read_excel(fp: Path, sheet: str) -> pd.DataFrame:
-    if fp.exists():
-        try:
-            return pd.read_excel(fp, sheet_name=sheet)
-        except Exception:
-            return pd.DataFrame()
+    """Return ``pd.DataFrame`` from *fp* ``sheet`` or an empty frame on error."""
+    try:
+        return safe_read_excel(fp, sheet_name=sheet)
+    except FileNotFoundError:
+        log.warning("Excel file not found: %s", fp)
+    except Exception as e:  # noqa: BLE001
+        log.warning("Failed reading %s [%s]: %s", fp, sheet, e)
     return pd.DataFrame()
 
 

--- a/shift_suite/tasks/utils.py
+++ b/shift_suite/tasks/utils.py
@@ -101,6 +101,42 @@ def safe_sheet(name: str, *, for_path: bool = False) -> str:
     return out or "sheet"
 
 
+def safe_read_excel(fp: Path | str, **kwargs: Any) -> DataFrame:
+    """Read an Excel file with basic error handling.
+
+    Parameters
+    ----------
+    fp : Path | str
+        Excel file path.
+    **kwargs : Any
+        Options forwarded to ``pd.read_excel``.
+
+    Returns
+    -------
+    DataFrame
+        Loaded DataFrame.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file does not exist.
+    ValueError
+        For empty files or other read errors.
+    """
+    path = Path(fp)
+    if not path.exists():
+        log.error("Excel file not found: %s", path)
+        raise FileNotFoundError(path)
+    try:
+        return pd.read_excel(path, **kwargs)
+    except pd.errors.EmptyDataError as e:
+        log.error("Excel file '%s' is empty: %s", path, e)
+        raise ValueError(f"Excel file '{path}' is empty") from e
+    except Exception as e:  # noqa: BLE001
+        log.error("Failed to read Excel file '%s': %s", path, e)
+        raise ValueError(f"Failed to read Excel file '{path}': {e}") from e
+
+
 # ────────────────── 4. DataFrame 保存 ──────────────────
 def save_df_xlsx(
     df: DataFrame,
@@ -326,6 +362,7 @@ __all__: Sequence[str] = [
     "to_hhmm",
     "gen_labels",
     "safe_sheet",
+    "safe_read_excel",
     "save_df_xlsx",
     "write_meta",
     "safe_make_archive",


### PR DESCRIPTION
## Summary
- handle errors more robustly when reading Excel files
- expose `safe_read_excel` helper
- use `safe_read_excel` inside the report generator and Streamlit app

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas and others)*

------
https://chatgpt.com/codex/tasks/task_e_6841b76108e48333a45a78540a73f821