### PR TITLE
Fix Windows watcher errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,6 +25,11 @@ import datetime
 import io
 import logging
 import os
+
+# Streamlit's watchdog can print repeated errors on Windows
+# unless STREAMLIT_WATCHER_TYPE is set to "poll".
+os.environ.setdefault("STREAMLIT_WATCHER_TYPE", "poll")
+
 import re
 import tempfile
 import zipfile


### PR DESCRIPTION
## Summary
- set default `STREAMLIT_WATCHER_TYPE` in `app.py`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6841b9aa85108333b6786ee2c4008e7d