### PR TITLE
Handle blank cells as off days

### DIFF
--- a/shift_suite/tasks/io_excel.py
+++ b/shift_suite/tasks/io_excel.py
@@ -379,7 +379,25 @@ def ingest_excel(
                 shift_code_raw = row_data.get(col_name_original_str, "")
                 code_val = _normalize(str(shift_code_raw))
 
-                if code_val in ("", "nan", "NaN") or code_val in DOW_TOKENS:
+                if code_val in ("", "nan", "NaN"):
+                    date_val_parsed_dt_date = date_col_map.get(str(col_name_original_str))
+                    if date_val_parsed_dt_date is not None:
+                        record_datetime_for_zero_slot = dt.datetime.combine(
+                            date_val_parsed_dt_date, dt.time(0, 0)
+                        )
+                        records.append(
+                            {
+                                "ds": record_datetime_for_zero_slot,
+                                "staff": staff,
+                                "role": role,
+                                "employment": employment,
+                                "code": "",
+                                "holiday_type": DEFAULT_HOLIDAY_TYPE,
+                                "parsed_slots_count": 0,
+                            }
+                        )
+                    continue
+                if code_val in DOW_TOKENS:
                     continue
                 if code_val not in code2slots:
                     if code_val not in unknown_codes:


### PR DESCRIPTION
## Summary
- treat empty shift cells as zero-slot records during Excel ingestion

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68424a69630c83338e417115f7627094