### PR TITLE
Fix shortage log merge bug

### DIFF
--- a/app.py
+++ b/app.py
@@ -2544,7 +2544,12 @@ def display_over_shortage_log_section(data_dir: Path) -> None:
 
     log_fp = data_dir / "over_shortage_log.csv"
     existing = over_shortage_log.load_log(log_fp)
-    merged = events.merge(existing, on=["date", "time", "type"], how="left")
+    merged = events.merge(
+        existing,
+        on=["date", "time", "type"],
+        how="left",
+        suffixes=("", "_log"),
+    )
 
     updated_rows = []
     reason_opts = [


### PR DESCRIPTION
## Summary
- merge over/shortage logs with suffixes to preserve count column

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68425ac5fa0c8333ab5ccbc0a7320a94