### PR TITLE
Add weekday/month period shortage summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ are automatically imported by `shift_suite/__init__.py`, so you can simply
   numbers from shift records.
 - **`shortage`** – Computes staff shortages based on heatmap data and outputs
   summary spreadsheets.
+- **`weekday_timeslot_summary` / `monthperiod_timeslot_summary`** –
+  Return average shortage counts by weekday or month period for each time slot
+  so you can create heatmaps highlighting recurring issues.
 - **`build_stats`** – Aggregates KPIs and produces overall and monthly
   statistics.
  - **`forecast`** – Builds demand series and forecasts future staffing needs via

--- a/shift_suite/__init__.py
+++ b/shift_suite/__init__.py
@@ -58,6 +58,12 @@ build_demand_series = _lazy_func("shift_suite.tasks.forecast", "build_demand_ser
 forecast_need = _lazy_func("shift_suite.tasks.forecast", "forecast_need")
 learn_roster = _lazy_func("shift_suite.tasks.rl", "learn_roster")
 build_staff_stats = _lazy_func("shift_suite.tasks.summary", "build_staff_stats")
+weekday_timeslot_summary = _lazy_func(
+    "shift_suite.tasks.shortage", "weekday_timeslot_summary"
+)
+monthperiod_timeslot_summary = _lazy_func(
+    "shift_suite.tasks.shortage", "monthperiod_timeslot_summary"
+)
 
 sys.modules["shift_suite.build_stats"] = import_module("shift_suite.tasks.build_stats")
 
@@ -78,4 +84,6 @@ __all__ = [
     "forecast_need",
     "learn_roster",
     "build_staff_stats",
+    "weekday_timeslot_summary",
+    "monthperiod_timeslot_summary",
 ]

--- a/tests/test_shortage_period_summary.py
+++ b/tests/test_shortage_period_summary.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import pandas as pd
+
+from shift_suite.tasks.shortage import (
+    shortage_and_brief,
+    weekday_timeslot_summary,
+    monthperiod_timeslot_summary,
+)
+from shift_suite.tasks.utils import gen_labels
+
+
+def _create_heatmap(out_dir: Path) -> None:
+    labels = gen_labels(30)[:1]
+    df = pd.DataFrame(
+        {
+            "need": [1],
+            "2024-06-01": [0],
+            "2024-06-11": [2],
+            "2024-06-21": [1],
+        },
+        index=labels,
+    )
+    df.to_excel(out_dir / "heat_ALL.xlsx")
+
+
+def test_weekday_timeslot_summary(tmp_path: Path) -> None:
+    _create_heatmap(tmp_path)
+    shortage_and_brief(tmp_path, slot=30)
+    df = weekday_timeslot_summary(tmp_path)
+    assert {"weekday", "timeslot", "avg_count"}.issubset(df.columns)
+    saturday_val = df.loc[df["weekday"] == "土曜日", "avg_count"].iloc[0]
+    assert saturday_val == 1
+
+
+def test_monthperiod_timeslot_summary(tmp_path: Path) -> None:
+    _create_heatmap(tmp_path)
+    shortage_and_brief(tmp_path, slot=30)
+    df = monthperiod_timeslot_summary(tmp_path)
+    assert {"month_period", "timeslot", "avg_count"}.issubset(df.columns)
+    early_val = df.loc[df["month_period"] == "月初(1-10日)", "avg_count"].iloc[0]
+    assert early_val == 1


### PR DESCRIPTION
## Summary
- support averaging shortage results by weekday or month period
- export helpers `weekday_timeslot_summary` and `monthperiod_timeslot_summary`
- document the new functions
- test summaries for weekday and month period

## Testing
- `ruff check .`
- `pytest -q` *(fails: Could not find a version that satisfies the requirement pandas==2.2.*)*

------
https://chatgpt.com/codex/tasks/task_e_68425dafe7b083338a6f07baef2b38ac