### PR TITLE
Fix employment column alias

### DIFF
--- a/shift_suite/tasks/io_excel.py
+++ b/shift_suite/tasks/io_excel.py
@@ -47,6 +47,7 @@ SHEET_COL_ALIAS = {
     "役職": "role",
     "role": "role",
     "雇用形態": "employment",
+    "雇用区分": "employment",
     "employment": "employment",
 }
 DOW_TOKENS = {"月", "火", "水", "木", "金", "土", "日", "明"}

--- a/tests/test_ingest_employment.py
+++ b/tests/test_ingest_employment.py
@@ -5,7 +5,11 @@ import pandas as pd
 from shift_suite.tasks.io_excel import ingest_excel
 
 
-def test_ingest_excel_employment(tmp_path: Path):
+import pytest
+
+
+@pytest.mark.parametrize("emp_col", ["雇用形態", "雇用区分"])
+def test_ingest_excel_employment(tmp_path: Path, emp_col: str):
     excel_fp = tmp_path / "shift.xlsx"
 
     wt = pd.DataFrame({"勤務記号": ["A"], "開始": ["09:00"], "終了": ["18:00"]})
@@ -13,7 +17,7 @@ def test_ingest_excel_employment(tmp_path: Path):
         {
             "氏名": ["山田"],
             "職種": ["看護師"],
-            "雇用形態": ["正社員"],
+            emp_col: ["正社員"],
             "2024-01-01": ["A"],
         }
     )


### PR DESCRIPTION
## Summary
- recognize `雇用区分` column as employment during Excel ingest
- test employment column alias both for `雇用形態` and `雇用区分`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684296e33c608333b61df65cd6f1eae7