### PR TITLE
Add daily cost computation

### DIFF
--- a/shift_suite/__init__.py
+++ b/shift_suite/__init__.py
@@ -64,6 +64,10 @@ weekday_timeslot_summary = _lazy_func(
 monthperiod_timeslot_summary = _lazy_func(
     "shift_suite.tasks.shortage", "monthperiod_timeslot_summary"
 )
+calculate_daily_cost = _lazy_func(
+    "shift_suite.tasks.daily_cost",
+    "calculate_daily_cost",
+)
 
 sys.modules["shift_suite.build_stats"] = import_module("shift_suite.tasks.build_stats")
 
@@ -86,4 +90,5 @@ __all__ = [
     "build_staff_stats",
     "weekday_timeslot_summary",
     "monthperiod_timeslot_summary",
+    "calculate_daily_cost",
 ]

--- a/shift_suite/tasks/daily_cost.py
+++ b/shift_suite/tasks/daily_cost.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Mapping, Literal
+
+import pandas as pd
+
+SLOT_MINUTES = 30
+
+
+def calculate_daily_cost(
+    long_df: pd.DataFrame,
+    wages: Mapping[str, float],
+    *,
+    by: Literal["staff", "role", "employment"],
+    slot_minutes: int = SLOT_MINUTES,
+) -> pd.DataFrame:
+    """Calculate daily labour cost from long format shift data.
+
+    Parameters
+    ----------
+    long_df : DataFrame
+        Shift records returned by :func:`ingest_excel`.
+    wages : Mapping[str, float]
+        Hourly wage keyed by the value of ``by`` column.
+    by : {'staff', 'role', 'employment'}
+        Column used to look up hourly wage.
+    slot_minutes : int, default 30
+        Minutes per timeslot represented by each row.
+
+    Returns
+    -------
+    DataFrame
+        ``date`` and ``cost`` columns with daily totals.
+    """
+    if by not in {"staff", "role", "employment"}:
+        raise ValueError("by must be 'staff', 'role' or 'employment'")
+    if "ds" not in long_df.columns:
+        raise ValueError("long_df must contain 'ds' column")
+    if by not in long_df.columns:
+        raise ValueError(f"long_df must contain '{by}' column")
+
+    df = long_df.copy()
+    df["date"] = pd.to_datetime(df["ds"]).dt.date
+    if "parsed_slots_count" in df.columns:
+        df = df[df["parsed_slots_count"] > 0]
+
+    hours_per_slot = slot_minutes / 60.0
+    df["wage"] = df[by].map(wages).fillna(0)
+    df["cost"] = df["wage"] * hours_per_slot
+
+    result = df.groupby("date")["cost"].sum().reset_index()
+    return result

--- a/tests/test_daily_cost.py
+++ b/tests/test_daily_cost.py
@@ -1,0 +1,35 @@
+import pandas as pd
+
+from shift_suite.tasks.daily_cost import calculate_daily_cost
+
+
+def test_calculate_daily_cost_by_staff():
+    df = pd.DataFrame(
+        {
+            "ds": pd.date_range("2024-01-01 09:00", periods=6, freq="30min"),
+            "staff": ["A"] * 3 + ["B"] * 3,
+            "role": ["N"] * 3 + ["C"] * 3,
+            "employment": ["FT"] * 6,
+            "parsed_slots_count": [1] * 6,
+        }
+    )
+    wages = {"A": 1000, "B": 2000}
+    res = calculate_daily_cost(df, wages, by="staff", slot_minutes=30)
+    assert res.shape[0] == 1
+    assert res.loc[0, "cost"] == 4500
+
+
+def test_calculate_daily_cost_by_role():
+    df = pd.DataFrame(
+        {
+            "ds": pd.date_range("2024-01-01 09:00", periods=4, freq="30min"),
+            "staff": ["A", "A", "B", "B"],
+            "role": ["N", "N", "C", "C"],
+            "employment": ["FT", "FT", "PT", "PT"],
+            "parsed_slots_count": [1] * 4,
+        }
+    )
+    wages = {"N": 1000, "C": 1500}
+    res = calculate_daily_cost(df, wages, by="role", slot_minutes=30)
+    assert res.loc[0, "cost"] == 2500
+


### PR DESCRIPTION
## Summary
- implement `calculate_daily_cost` to compute labour cost per day
- expose new function from package API
- test daily cost calculation for staff and role

## Testing
- `ruff check .`
- `pip install -q -r requirements.txt` *(fails: Could not find pandas)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6842a085c45c8333899efa210431cdf9