### PR TITLE
Improve config loading and add tests

### DIFF
--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -1,0 +1,22 @@
+import logging
+
+import shift_suite.config as config
+
+
+def test_load_config_missing_file(tmp_path, monkeypatch, caplog):
+    missing = tmp_path / "no.json"
+    monkeypatch.setattr(config, "_CONFIG_PATH", missing)
+    config._load_config.cache_clear()
+    with caplog.at_level(logging.WARNING):
+        assert config.get("x") is None
+    assert "not found" in caplog.text
+
+
+def test_load_config_invalid_json(tmp_path, monkeypatch, caplog):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ invalid", encoding="utf-8")
+    monkeypatch.setattr(config, "_CONFIG_PATH", bad)
+    config._load_config.cache_clear()
+    with caplog.at_level(logging.ERROR):
+        assert config.get("y", "d") == "d"
+    assert "Failed to parse" in caplog.text


### PR DESCRIPTION
## Summary
- log warnings and errors when `config.json` is missing or invalid
- test configuration loading behavior

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas/numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6842a3a168708333a42c2d4656b29adf