### PR TITLE
Add persistent log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ pytest -q
 
 Once the tests pass you can explore the modules described below.
 
+## Logging
+
+All commands log to ``shift_suite.log`` in the current directory in addition to
+printing to the console.  Set ``SHIFT_SUITE_LOG_FILE`` to override the path.
+
 ## Main modules
 
 - **`app.py`** – Launches the Streamlit based GUI.  The application guides you

--- a/shift_suite/logger_config.py
+++ b/shift_suite/logger_config.py
@@ -28,3 +28,9 @@ def configure_logging(level: int = logging.INFO) -> None:
     root = logging.getLogger()
     root.setLevel(level)
     root.addHandler(handler)
+
+    # Also write logs to file so they can be reviewed after GUI runs
+    log_file = os.getenv("SHIFT_SUITE_LOG_FILE", "shift_suite.log")
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    root.addHandler(file_handler)


### PR DESCRIPTION
## Summary
- log to `shift_suite.log` for easier troubleshooting
- document log file in README

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6842a53fad4c83339eef3377f525622d