### PR TITLE
Improve logging and warning messages

### DIFF
--- a/shift_suite/logger_config.py
+++ b/shift_suite/logger_config.py
@@ -22,7 +22,10 @@ def configure_logging(level: int = logging.INFO) -> None:
 
     handler = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter(
-        "%(asctime)s [%(levelname)s] %(name)s [%(module)s.%(funcName)s:%(lineno)d] - %(message)s"
+        (
+            "%(asctime)s [%(levelname)s] %(name)s "
+            "[%(module)s.%(funcName)s:%(lineno)d] - %(message)s"
+        )
     )
     handler.setFormatter(formatter)
     root = logging.getLogger()

--- a/shift_suite/tasks/report_generator.py
+++ b/shift_suite/tasks/report_generator.py
@@ -78,8 +78,8 @@ def generate_summary_report(out_dir: Path | str) -> Path:
             if not date_cols.empty:
                 min_date = date_cols.min().date().isoformat()
                 max_date = date_cols.max().date().isoformat()
-        except Exception:
-            pass
+        except Exception as e:
+            log.warning("Failed to load heat map '%s': %s", heat_fp, e)
 
     lack_h_total = float(role_df.get("lack_h", pd.Series()).sum())
     excess_h_total = float(role_df.get("excess_h", pd.Series()).sum())


### PR DESCRIPTION
## Summary
- split long log format string
- warn if heatmap file can't be read

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6842d4384fd083339377c4eaa9cec551