### PR TITLE
Add text summaries for analysis modules

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11,6 +11,7 @@ from shift_suite import build_heatmap, ingest_excel, shortage_and_brief, summary
 from shift_suite.h2hire import build_hire_plan as build_hire_plan_from_shortage
 from shift_suite.tasks.cost_benefit import analyze_cost_benefit
 from shift_suite.utils import safe_make_archive
+from shift_suite.tasks.report_generator import generate_summary_report
 
 log = logging.getLogger(__name__)
 
@@ -114,6 +115,11 @@ def main():
         except Exception as e:
             log.error("cost-benefit analysis failed: %s", e)
     summary.build_staff_stats(long, out)
+
+    try:
+        generate_summary_report(out)
+    except Exception as e:
+        log.error("summary report generation failed: %s", e)
 
     if args.zip:
         safe_make_archive(out, out.with_suffix(".zip"))

--- a/shift_suite/tasks/build_stats.py
+++ b/shift_suite/tasks/build_stats.py
@@ -759,4 +759,33 @@ def build_stats(
     except Exception as e:
         log.error(f"stats.xlsx の書き出し中にエラーが発生しました: {e}", exc_info=True)
 
+    # text summary
+    try:
+        summary_fp = out_dir_path / "stats_summary.txt"
+        lack_total = int(
+            round(
+                overall_df.loc[
+                    (overall_df["summary_item"] == "lack")
+                    & overall_df["metric"].str.contains("(hours)"),
+                    "value",
+                ].sum()
+            )
+        )
+        excess_total = int(
+            round(
+                overall_df.loc[
+                    (overall_df["summary_item"] == "excess")
+                    & overall_df["metric"].str.contains("(hours)"),
+                    "value",
+                ].sum()
+            )
+        )
+        lines = [
+            f"lack_hours_total: {lack_total}",
+            f"excess_hours_total: {excess_total}",
+        ]
+        summary_fp.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    except Exception as e:  # noqa: BLE001
+        log.debug(f"failed to write stats summary: {e}")
+
     log.info("=== build_stats end ===")

--- a/shift_suite/tasks/cost_benefit.py
+++ b/shift_suite/tasks/cost_benefit.py
@@ -94,4 +94,14 @@ def analyze_cost_benefit(
     # Excel 保存
     df.to_excel(out_dir / "cost_benefit.xlsx")
 
+    # text summary
+    summary_fp = out_dir / "cost_benefit_summary.txt"
+    try:
+        min_row = df["Cost_JPY"].idxmin()
+        min_cost = int(df.loc[min_row, "Cost_JPY"])
+        lines = [f"lowest_cost_scenario: {min_row}", f"cost_jpy: {min_cost}"]
+        summary_fp.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    except Exception:  # noqa: BLE001
+        pass
+
     return df

--- a/shift_suite/tasks/forecast.py
+++ b/shift_suite/tasks/forecast.py
@@ -357,6 +357,14 @@ def forecast_need(
         periods=periods,
         created=str(dt.datetime.now()),
     )
+
+    # text summary
+    try:
+        summary_fp = excel_out.with_suffix(".summary.txt")
+        lines = [f"model: {sel}", f"mape: {float(np.round(sel_mape, 4))}"]
+        summary_fp.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    except Exception as e:  # noqa: BLE001
+        log.debug(f"forecast summary write failed: {e}")
     try:
         hist_row = pd.DataFrame(
             {

--- a/shift_suite/tasks/h2hire.py
+++ b/shift_suite/tasks/h2hire.py
@@ -77,6 +77,18 @@ def build_hire_plan(
 
     out_fp = Path(out_dir) / out_excel
     df_out.to_excel(out_fp, index=False)
+
+    # text summary
+    summary_fp = out_fp.with_suffix(".txt")
+    try:
+        summary_lines = [
+            f"total_hire_fte: {int(df_out['hire_fte'].sum())}",
+            f"est_monthly_pay_total: {int(df_out['est_monthly_pay'].sum())}",
+            f"est_recruit_cost_total: {int(df_out['est_recruit_cost'].sum())}",
+        ]
+        summary_fp.write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
+    except Exception as e:  # noqa: BLE001
+        log.debug(f"failed writing hire plan summary: {e}")
     return out_fp
 
 

--- a/shift_suite/tasks/hire_plan.py
+++ b/shift_suite/tasks/hire_plan.py
@@ -77,4 +77,12 @@ def build_hire_plan(
         }
         pd.DataFrame(meta, index=[0]).to_excel(writer, sheet_name="meta", index=False)
 
+    # text summary
+    summary_fp = out_path.with_suffix(".txt")
+    try:
+        lines = [f"total_hire_need: {int(summary['hire_need'].sum())}"]
+        summary_fp.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    except Exception:  # noqa: BLE001
+        pass
+
     return summary

--- a/shift_suite/tasks/shortage.py
+++ b/shift_suite/tasks/shortage.py
@@ -771,6 +771,19 @@ def shortage_and_brief(
         ],
     )
 
+    # ── text summary output ────────────────────────────────────────────────
+    summary_fp = out_dir_path / "shortage_summary.txt"
+    try:
+        total_lack_h = int(round(role_summary_df.get("lack_h", pd.Series()).sum()))
+        total_excess_h = int(round(role_summary_df.get("excess_h", pd.Series()).sum()))
+        summary_lines = [
+            f"total_lack_hours: {total_lack_h}",
+            f"total_excess_hours: {total_excess_h}",
+        ]
+        summary_fp.write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
+    except Exception as e:  # noqa: BLE001
+        log.debug(f"failed writing shortage summary text: {e}")
+
     log.info(
         (
             f"[shortage] completed — shortage_time → {fp_shortage_time.name}, "


### PR DESCRIPTION
## Summary
- export shortage totals to `shortage_summary.txt`
- write hire-plan stats to `hire_plan.txt` and `hire_plan.xlsx`
- produce cost-benefit, stats and forecast summaries in text form
- CLI now generates the markdown summary report

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6846700b1ff883339dbd3b8374efd6f8