### PR TITLE
Implement shift assignment optimizer

### DIFF
--- a/shift_suite/tasks/assignment.py
+++ b/shift_suite/tasks/assignment.py
@@ -1,0 +1,162 @@
+"""Shift assignment using OR-Tools CP-SAT."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+import pandas as pd
+
+try:
+    from ortools.sat.python import cp_model
+except Exception:  # pragma: no cover - optional dependency
+    cp_model = None  # type: ignore
+
+from .utils import log
+
+
+class ShiftSolutionPrinter(cp_model.CpSolverSolutionCallback):  # type: ignore
+    """Print intermediate solutions during search."""
+
+    def __init__(self, variables, staff_ids, dates, limit: int) -> None:
+        super().__init__()
+        self._variables = variables
+        self._staff_ids = staff_ids
+        self._dates = dates
+        self._solution_count = 0
+        self._limit = limit
+
+    def on_solution_callback(self) -> None:
+        self._solution_count += 1
+        log.info(
+            "Solution %d found with objective %.2f",
+            self._solution_count,
+            self.ObjectiveValue(),
+        )
+        if self._solution_count >= self._limit:
+            log.info("Stopping search after %d solutions", self._limit)
+            self.StopSearch()
+
+    def solution_count(self) -> int:
+        return self._solution_count
+
+
+def generate_optimal_schedule(
+    roster_df: pd.DataFrame,
+    staff_df: pd.DataFrame,
+    leave_df: pd.DataFrame,
+    config: Dict,
+) -> pd.DataFrame:
+    """Generate an optimal shift schedule.
+
+    Parameters
+    ----------
+    roster_df:
+        DataFrame with columns ``date`` and ``required_personnel``.
+    staff_df:
+        DataFrame indexed by ``staff_id`` with at least columns ``name`` and ``wage``.
+    leave_df:
+        DataFrame with columns ``staff_id`` and ``date`` listing leave days.
+    config:
+        Dictionary of solver options. Keys include ``time_limit_phase1``,
+        ``time_limit_phase2``, ``max_consecutive_work_days`` and ``window_for_off_days``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Schedule with columns ``date``, ``staff_id`` and ``name``. Empty when no
+        solution is found or OR-Tools is unavailable.
+    """
+    if cp_model is None:
+        log.error("ortools is not installed; assignment cannot run")
+        return pd.DataFrame()
+
+    staff_ids = staff_df.index.tolist()
+    dates = pd.to_datetime(roster_df["date"]).dt.date.tolist()
+    num_days = len(dates)
+
+    required_personnel = dict(zip(dates, roster_df["required_personnel"]))
+    wages = dict(zip(staff_ids, staff_df["wage"]))
+
+    leave_set = set(
+        (row["staff_id"], pd.to_datetime(row["date"]).date())
+        for _, row in leave_df.iterrows()
+    )
+
+    model = cp_model.CpModel()
+    x = {
+        (s_id, d): model.NewBoolVar(f"x_{s_id}_{d}")
+        for s_id in staff_ids
+        for d in dates
+    }
+
+    for d in dates:
+        model.Add(sum(x[(s_id, d)] for s_id in staff_ids) == required_personnel[d])
+
+    for s_id, d in leave_set:
+        if d in dates:
+            model.Add(x[(s_id, d)] == 0)
+
+    max_consecutive_days = config.get("max_consecutive_work_days", 5)
+    for s_id in staff_ids:
+        for i in range(num_days - max_consecutive_days):
+            window = [dates[i + j] for j in range(max_consecutive_days + 1)]
+            model.Add(sum(x[(s_id, d)] for d in window) <= max_consecutive_days)
+
+    window_size = config.get("window_for_off_days", 7)
+    for s_id in staff_ids:
+        for i in range(num_days - window_size + 1):
+            window = [dates[i + j] for j in range(window_size)]
+            model.Add(sum(x[(s_id, d)] for d in window) < window_size)
+
+    total_cost_var = model.NewIntVar(0, sum(wages.values()) * num_days, "total_cost")
+    model.Add(
+        total_cost_var
+        == sum(x[(s_id, d)] * wages[s_id] for s_id in staff_ids for d in dates)
+    )
+    model.Minimize(total_cost_var)
+
+    solver = cp_model.CpSolver()
+    solver.parameters.max_time_in_seconds = config.get("time_limit_phase1", 60)
+    solver.parameters.num_search_workers = os.cpu_count() or 1
+
+    status1 = solver.Solve(model)
+    if status1 not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
+        log.error("Phase 1 failed to find a solution")
+        return pd.DataFrame()
+
+    optimal_cost = solver.Value(total_cost_var)
+    log.info("Phase 1 optimal cost: %s", optimal_cost)
+
+    model.Add(total_cost_var == optimal_cost)
+
+    workload_vars = {
+        s_id: model.NewIntVar(0, num_days, f"workload_{s_id}") for s_id in staff_ids
+    }
+    for s_id in staff_ids:
+        model.Add(workload_vars[s_id] == sum(x[(s_id, d)] for d in dates))
+
+    max_workload = model.NewIntVar(0, num_days, "max_workload")
+    min_workload = model.NewIntVar(0, num_days, "min_workload")
+    model.AddMaxEquality(max_workload, list(workload_vars.values()))
+    model.AddMinEquality(min_workload, list(workload_vars.values()))
+    fairness_diff = model.NewIntVar(0, num_days, "fairness_diff")
+    model.Add(fairness_diff == max_workload - min_workload)
+    model.Minimize(fairness_diff)
+
+    solver.parameters.max_time_in_seconds = config.get("time_limit_phase2", 60)
+
+    status2 = solver.Solve(model)
+    if status2 not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
+        log.error("Phase 2 failed to find a fair solution")
+        return pd.DataFrame()
+
+    schedule_data = []
+    for d in dates:
+        for s_id in staff_ids:
+            if solver.Value(x[(s_id, d)]):
+                schedule_data.append(
+                    {"date": d, "staff_id": s_id, "name": staff_df.loc[s_id, "name"]}
+                )
+
+    return pd.DataFrame(schedule_data)

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -1,0 +1,32 @@
+import pandas as pd
+import pytest
+
+from shift_suite.tasks.assignment import generate_optimal_schedule
+
+
+def test_generate_optimal_schedule_basic():
+    pytest.importorskip("ortools")
+    roster_df = pd.DataFrame(
+        {
+            "date": pd.date_range("2024-01-01", periods=3),
+            "required_personnel": [1, 1, 1],
+        }
+    )
+    staff_df = pd.DataFrame(
+        {"name": ["Alice", "Bob"], "wage": [100, 100]}, index=[1, 2]
+    )
+    leave_df = pd.DataFrame({"staff_id": [1], "date": ["2024-01-02"]})
+
+    config = {
+        "time_limit_phase1": 5,
+        "time_limit_phase2": 5,
+        "max_consecutive_work_days": 2,
+        "window_for_off_days": 3,
+    }
+
+    schedule = generate_optimal_schedule(roster_df, staff_df, leave_df, config)
+    assert not schedule.empty
+    assert set(schedule.columns) == {"date", "staff_id", "name"}
+    # Ensure leave day is respected
+    day2 = pd.to_datetime("2024-01-02").date()
+    assert schedule[schedule["date"] == day2]["staff_id"].tolist() == [2]


### PR DESCRIPTION
## Summary
- add new OR-Tools based assignment module with cost and fairness optimisation
- add basic unit test for assignment generation

## Testing
- `ruff check .`
- `pytest -q` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68468ff224588333a9c8809c6233dbb8