### PR TITLE
Add weekday info to heatmap tooltips

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,7 +60,12 @@ from shift_suite.tasks import (
     leave_analyzer,  # ★ 新規インポート
     over_shortage_log,
 )
-from shift_suite.tasks.utils import safe_read_excel, safe_sheet, _parse_as_date
+from shift_suite.tasks.utils import (
+    safe_read_excel,
+    safe_sheet,
+    _parse_as_date,
+    date_with_weekday,
+)
 from shift_suite import config
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -1892,6 +1897,7 @@ def display_heatmap_tab(tab_container, data_dir):
                             "y": _("Time"),
                             "color": _("Raw Count"),
                         },
+                        x=[date_with_weekday(c) for c in disp_df_heat.columns],
                         title="スタッフ配置ヒートマップ",
                     )
                 else:
@@ -1931,6 +1937,7 @@ def display_heatmap_tab(tab_container, data_dir):
                                     "y": _("Time"),
                                     "color": _("Ratio (staff ÷ need)"),
                                 },
+                                x=[date_with_weekday(c) for c in ratio_display_df.columns],
                                 title="充足率ヒートマップ",
                             )
                         else:
@@ -2890,6 +2897,7 @@ def display_optimization_tab(tab_container, data_dir):
             aspect="auto",
             color_continuous_scale="Blues",
             labels={"x": _("Date"), "y": _("Time"), "color": _("Surplus vs Need")},
+            x=[date_with_weekday(c) for c in df_surplus.columns],
             title="必要人数に対する余剰人員ヒートマップ",
         )
         st.plotly_chart(fig_surplus, use_container_width=True, key="surplus_need_heat")
@@ -2907,6 +2915,7 @@ def display_optimization_tab(tab_container, data_dir):
             aspect="auto",
             color_continuous_scale="Greens",
             labels={"x": _("Date"), "y": _("Time"), "color": _("Margin vs Upper")},
+            x=[date_with_weekday(c) for c in df_margin.columns],
             title="上限人数までの余白ヒートマップ",
         )
         st.plotly_chart(fig_margin, use_container_width=True, key="margin_upper_heat")
@@ -2926,6 +2935,7 @@ def display_optimization_tab(tab_container, data_dir):
             zmin=0,
             zmax=1,
             labels={"x": _("Date"), "y": _("Time"), "color": _("Optimization Score")},
+            x=[date_with_weekday(c) for c in df_score.columns],
             title="最適化スコア ヒートマップ",
         )
         st.plotly_chart(fig_score, use_container_width=True, key="optimization_heat")

--- a/dash_app.py
+++ b/dash_app.py
@@ -20,6 +20,7 @@ import plotly.express as px
 from dash import Input, Output, callback, dcc, html
 
 from shift_suite.i18n import translate as _
+from shift_suite.tasks.utils import date_with_weekday
 from shift_suite.tasks.constants import SUMMARY5 as SUMMARY5_CONST
 from shift_suite.tasks.dashboard import load_leave_results_from_dir
 
@@ -279,6 +280,7 @@ def page_shortage():
                     zmin=0,
                     zmax=1,
                     labels=dict(x=_("Date"), y=_("Time"), color=_("Shortage Ratio")),
+                    x=[date_with_weekday(c) for c in shortage_ratio_df.columns],
                     title="不足率ヒートマップ",
                 ),
             ),
@@ -410,6 +412,7 @@ def update_heatmap(mode: str, zmax_val: float, zmode: str):
             zmin=0,
             zmax=zmax_val,
             labels=dict(x="日付", y="時間帯", color="配置人数"),
+            x=[date_with_weekday(c) for c in heat_staff_data.columns],
             title="スタッフ配置ヒートマップ",
         )
         return fig, slider_disabled, zmax_val
@@ -424,6 +427,7 @@ def update_heatmap(mode: str, zmax_val: float, zmode: str):
         labels=dict(
             x="日付", y="時間帯", color="充足率 (実績/必要)"
         ),  # ★ ラベル日本語化
+        x=[date_with_weekday(c) for c in ratio_calculated_df.columns],
         title="充足率ヒートマップ",
     )
     return fig, True, zmax_val

--- a/shift_suite/tasks/dashboard.py
+++ b/shift_suite/tasks/dashboard.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import pandas as pd
 import plotly.express as px
 
+from .utils import date_with_weekday
+
 from shift_suite.i18n import translate as _
 
 from . import leave_analyzer
@@ -84,6 +86,7 @@ def shortage_heatmap(lack_ratio_df: pd.DataFrame):
         aspect="auto",
         color_continuous_scale="Reds",
         labels={"x": _("Date"), "y": _("Time"), "color": _("Shortage Ratio")},
+        x=[date_with_weekday(c) for c in lack_ratio_df.columns],
     )
     return fig
 

--- a/shift_suite/tasks/utils.py
+++ b/shift_suite/tasks/utils.py
@@ -361,6 +361,18 @@ def _parse_as_date(column_name: Any) -> dt.date | None:
     return None
 
 
+# ────────────────── 8. Date + Weekday Helpers ──────────────────
+def date_with_weekday(date_val: Any) -> str:
+    """Return ``YYYY-MM-DD(曜日)`` for the given date string."""
+
+    try:
+        dt_val = pd.to_datetime(date_val, errors="raise")
+    except Exception:  # noqa: BLE001 - parse failure
+        return str(date_val)
+    weekday_jp = "月火水木金土日"[dt_val.weekday()]
+    return dt_val.strftime("%Y-%m-%d") + f"({weekday_jp})"
+
+
 # ────────────────── 9. Public Re-export ──────────────────
 __all__: Sequence[str] = [
     "log",
@@ -376,4 +388,5 @@ __all__: Sequence[str] = [
     "derive_max_staff",
     "calculate_jain_index",
     "_parse_as_date",  # ★追加
+    "date_with_weekday",
 ]

--- a/tests/test_utils_basic.py
+++ b/tests/test_utils_basic.py
@@ -29,3 +29,8 @@ def test_to_hhmm_variants():
     assert utils.to_hhmm("23:45") == "23:45"
     assert utils.to_hhmm("12:00:59") == "12:00"
     assert utils.to_hhmm(None) is None
+
+
+def test_date_with_weekday_formatting():
+    s = utils.date_with_weekday("2024-06-01")
+    assert s.startswith("2024-06-01") and "(" in s and ")" in s


### PR DESCRIPTION
## Summary
- show weekday in heatmap columns by adding `date_with_weekday` helper
- display weekday labels on heatmaps in Streamlit and Dash GUIs
- expose helper from `utils`
- test weekday formatting

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68478d5442188333a3769d3376278607