### PR TITLE
Implement wage cost analysis features

### DIFF
--- a/shift_suite/tasks/__init__.py
+++ b/shift_suite/tasks/__init__.py
@@ -22,6 +22,8 @@ _module_map = {
     "WorkPatternAnalyzer": "shift_suite.tasks.analyzers.work_pattern",
     "ShortageFactorAnalyzer": "shift_suite.tasks.shortage_factor_analyzer",
     "create_optimal_hire_plan": "shift_suite.tasks.optimal_hire_plan",
+    "optimal_hire_plan": "shift_suite.tasks.optimal_hire_plan",
+    "daily_cost": "shift_suite.tasks.daily_cost",
 }
 
 

--- a/tests/test_daily_cost.py
+++ b/tests/test_daily_cost.py
@@ -24,11 +24,12 @@ def test_calculate_daily_cost_by_role():
         {
             "ds": pd.date_range("2024-01-01 09:00", periods=4, freq="30min"),
             "staff": ["A", "A", "B", "B"],
-            "role": ["N", "N", "C", "C"],
+            "role": ["Nurse", "Nurse", "Care", "Care"],
             "employment": ["FT", "FT", "PT", "PT"],
             "parsed_slots_count": [1] * 4,
         }
     )
-    wages = {"N": 1000, "C": 1500}
+    wages = {"Nurse": 1500, "Care": 1200}
     res = calculate_daily_cost(df, wages, by="role", slot_minutes=30)
-    assert res.loc[0, "cost"] == 2500
+    assert res.loc[0, "cost"] == (1500 * 0.5 * 2) + (1200 * 0.5 * 2)
+    assert res["cost"].sum() == 2700


### PR DESCRIPTION
## Summary
- support dynamic wage input for cost analysis
- map daily cost module in tasks init
- test daily_cost by role with new wages
- compute daily cost and store as daily_cost.xlsx
- display daily cost results in dashboard

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6848c376270c83338afd13103e53bc21