### PR TITLE
Improve configuration reloading

### DIFF
--- a/shift_suite/config.py
+++ b/shift_suite/config.py
@@ -5,6 +5,7 @@ import logging
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
+import os
 
 from .logger_config import configure_logging
 
@@ -12,7 +13,9 @@ from .logger_config import configure_logging
 configure_logging()
 log = logging.getLogger(__name__)
 
-_CONFIG_PATH = Path(__file__).with_name("config.json")
+_CONFIG_PATH = Path(
+    os.getenv("SHIFT_SUITE_CONFIG", str(Path(__file__).with_name("config.json")))
+)
 
 
 @lru_cache(maxsize=1)
@@ -34,3 +37,11 @@ def _load_config() -> dict[str, Any]:
 def get(key: str, default: Any = None) -> Any:
     """Return configuration value for ``key`` or ``default`` if missing."""
     return _load_config().get(key, default)
+
+
+def reload_config() -> None:
+    """Clear cached configuration so it will be reloaded on next access."""
+    _load_config.cache_clear()
+
+
+__all__ = ["get", "reload_config"]

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -20,3 +20,14 @@ def test_load_config_invalid_json(tmp_path, monkeypatch, caplog):
     with caplog.at_level(logging.ERROR):
         assert config.get("y", "d") == "d"
     assert "Failed to parse" in caplog.text
+
+
+def test_reload_config(tmp_path, monkeypatch):
+    cfg = tmp_path / "c.json"
+    cfg.write_text('{"k": 1}', encoding="utf-8")
+    monkeypatch.setattr(config, "_CONFIG_PATH", cfg)
+    config.reload_config()
+    assert config.get("k") == 1
+    cfg.write_text('{"k": 2}', encoding="utf-8")
+    config.reload_config()
+    assert config.get("k") == 2


### PR DESCRIPTION
## Summary
- add environment override for config.json path
- implement `reload_config` helper
- test reloading behavior

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6848fc20700c8333916ae590f81c0374