### PR TITLE
Improve summary logging

### DIFF
--- a/shift_suite/tasks/cost_benefit.py
+++ b/shift_suite/tasks/cost_benefit.py
@@ -14,8 +14,11 @@ cost_benefit.py ── “採用 / 派遣 / 漏れ (罰金)” コストを試�
 from __future__ import annotations
 
 from pathlib import Path
+import logging
 
 import pandas as pd
+
+log = logging.getLogger(__name__)
 
 
 def analyze_cost_benefit(
@@ -101,7 +104,7 @@ def analyze_cost_benefit(
         min_cost = int(df.loc[min_row, "Cost_JPY"])
         lines = [f"lowest_cost_scenario: {min_row}", f"cost_jpy: {min_cost}"]
         summary_fp.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    except Exception:  # noqa: BLE001
-        pass
+    except Exception as e:  # noqa: BLE001
+        log.warning("Failed to write summary %s: %s", summary_fp, e)
 
     return df

--- a/shift_suite/tasks/hire_plan.py
+++ b/shift_suite/tasks/hire_plan.py
@@ -13,8 +13,11 @@ hire_plan.py  ── “必要な採用人数” を算出するユーティリ�
 from __future__ import annotations
 
 from pathlib import Path
+import logging
 
 import pandas as pd
+
+log = logging.getLogger(__name__)
 
 
 def build_hire_plan(
@@ -82,7 +85,7 @@ def build_hire_plan(
     try:
         lines = [f"total_hire_need: {int(summary['hire_need'].sum())}"]
         summary_fp.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    except Exception:  # noqa: BLE001
-        pass
+    except Exception as e:  # noqa: BLE001
+        log.warning("Failed to write summary %s: %s", summary_fp, e)
 
     return summary


### PR DESCRIPTION
## Summary
- add logger setup for cost_benefit and hire_plan
- warn when summary file write fails

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas and numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68491d08499083338ffaeea990636937