### PR TITLE
Fix torch requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ prophet==1.1.6         #  Python 3.12 で動作する最新版
 stable-baselines3>=2.3
 gymnasium>=0.29        #  明示
 # 固定した CPU 版 PyTorch を使用する
-torch==2.3.1+cpu
+torch
 
 # ─── misc / utils ───
 python-pptx>=0.6


### PR DESCRIPTION
## Summary
- use unpinned `torch` instead of CPU-specific version in requirements

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas and others)*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas==2.2.*)*

------
https://chatgpt.com/codex/tasks/task_e_68491e39927c8333be8926b127a96cdf