### PR TITLE
Add parquet saving and dependency

### DIFF
--- a/app.py
+++ b/app.py
@@ -1114,6 +1114,9 @@ if run_button_clicked:
                     slot_minutes=param_slot,
                     year_month_cell_location=param_year_month_cell,
                 )
+                parquet_fp = out_dir_exec / "intermediate_data.parquet"
+                long_df.to_parquet(parquet_fp)
+                st.session_state["intermediate_parquet_path"] = str(parquet_fp)
                 st.session_state.analysis_status["ingest"] = "success"
                 log.info(
                     f"Ingest完了. long_df shape: {long_df.shape}, wt_df shape: {wt_df.shape if wt_df is not None else 'N/A'}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "statsmodels>=0.14",
     "scikit-learn>=1.4",
     "openpyxl>=3.1",
+    "pyarrow>=15.0",
     "pillow>=10.0"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pandas==2.2.*
 numpy==1.26.*
 openpyxl==3.1.*
 XlsxWriter>=3.2
+pyarrow>=15.0
 
 # ─── visual / web ───
 streamlit>=1.44


### PR DESCRIPTION
## Summary
- store intermediate analysis data in `out/intermediate_data.parquet`
- record path in session state
- depend on `pyarrow` for parquet support

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684935c50e088333b13d210f7fd91dd3