### PR TITLE
Switch fairness & RL outputs to Parquet

### DIFF
--- a/shift_suite/tasks/fairness.py
+++ b/shift_suite/tasks/fairness.py
@@ -102,27 +102,13 @@ def run_fairness(
                 "night_ratio",
             ]
         )
-        pd.DataFrame({"metric": ["jain_index"], "value": [1.0]}).to_excel(
-            out_dir_path / "fairness_before.xlsx",
-            sheet_name="meta_summary",
+        pd.DataFrame({"metric": ["jain_index"], "value": [1.0]}).to_parquet(
+            out_dir_path / "fairness_before.parquet",
             index=False,
         )
-        empty_summary.to_excel(
-            out_dir_path / "fairness_before.xlsx",
-            sheet_name="before_summary",
+        empty_summary.to_parquet(
+            out_dir_path / "fairness_after.parquet",
             index=False,
-            mode="a",
-            if_sheet_exists="replace",
-        )
-        pd.DataFrame({"metric": ["jain_index"], "value": [1.0]}).to_excel(
-            out_dir_path / "fairness_after.xlsx", sheet_name="meta_summary", index=False
-        )
-        empty_summary.to_excel(
-            out_dir_path / "fairness_after.xlsx",
-            sheet_name="after_summary",
-            index=False,
-            mode="a",
-            if_sheet_exists="replace",
         )
         return
 
@@ -284,38 +270,22 @@ def run_fairness(
     log.debug(f"[fairness] summary_df sample:\n{summary_df.head()}")
 
     summary_df.attrs["jain_index"] = jain_index_val
-    before_fp_path = out_dir_path / "fairness_before.xlsx"
-    after_fp_path = out_dir_path / "fairness_after.xlsx"
+    before_fp_path = out_dir_path / "fairness_before.parquet"
+    after_fp_path = out_dir_path / "fairness_after.parquet"
 
     try:
-        with pd.ExcelWriter(before_fp_path, engine="openpyxl") as wb_before:
-            summary_df.to_excel(wb_before, sheet_name="before_summary", index=False)
-            meta_df_before = pd.DataFrame(
-                {
-                    "metric": [
-                        "jain_night_ratio",
-                        "jain_night_slots",
-                        "jain_total_slots",
-                    ],
-                    "value": [jain_night_ratio, jain_night_slots, jain_total_slots],
-                }
-            )
-            meta_df_before.to_excel(wb_before, sheet_name="meta_summary", index=False)
-        log.info(f"[fairness] fairness_before.xlsx 保存 (Jain: {jain_index_val:.3f})")
-
-        with pd.ExcelWriter(after_fp_path, engine="openpyxl") as wa_after:
-            summary_df.to_excel(wa_after, sheet_name="after_summary", index=False)
-            meta_df_after = pd.DataFrame(
-                {
-                    "metric": [
-                        "jain_night_ratio",
-                        "jain_night_slots",
-                        "jain_total_slots",
-                    ],
-                    "value": [jain_night_ratio, jain_night_slots, jain_total_slots],
-                }
-            )
-            meta_df_after.to_excel(wa_after, sheet_name="meta_summary", index=False)
-        log.info(f"[fairness] fairness_after.xlsx 保存 (Jain: {jain_index_val:.3f})")
+        meta_df = pd.DataFrame(
+            {
+                "metric": [
+                    "jain_night_ratio",
+                    "jain_night_slots",
+                    "jain_total_slots",
+                ],
+                "value": [jain_night_ratio, jain_night_slots, jain_total_slots],
+            }
+        )
+        meta_df.to_parquet(before_fp_path, index=False)
+        summary_df.to_parquet(after_fp_path, index=False)
+        log.info(f"[fairness] fairness_before.parquet / fairness_after.parquet 保存 (Jain: {jain_index_val:.3f})")
     except Exception as e:
-        log.error(f"[fairness] Excel書出エラー: {e}", exc_info=True)
+        log.error(f"[fairness] Parquet書出エラー: {e}", exc_info=True)

--- a/shift_suite/tasks/rl.py
+++ b/shift_suite/tasks/rl.py
@@ -15,7 +15,7 @@ import numpy as np
 import pandas as pd
 from stable_baselines3 import PPO
 
-from .utils import log, save_df_xlsx, write_meta
+from .utils import log, save_df_parquet, write_meta
 
 
 # ═════════════════ Env ═════════════════
@@ -183,7 +183,7 @@ def learn_roster(
         ds_col = ds_col.iloc[: len(roster)]
 
     out_df = pd.DataFrame({"ds": ds_col.values, "roster": roster})
-    save_df_xlsx(out_df, excel_out, sheet_name="rl_roster")
+    save_df_parquet(out_df, excel_out)
 
     # meta
     note = "model_predict" if use_saved_model else "ppo_train"

--- a/tests/test_learn_roster.py
+++ b/tests/test_learn_roster.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 
 
-def test_learn_roster_generates_excel(tmp_path, monkeypatch):
+def test_learn_roster_generates_parquet(tmp_path, monkeypatch):
     # Stub gymnasium before importing rl
     fake_gym = types.SimpleNamespace()
 
@@ -61,12 +61,12 @@ def test_learn_roster_generates_excel(tmp_path, monkeypatch):
     forecast_csv = tmp_path / "forecast.csv"
     forecast_df.to_csv(forecast_csv, index=False)
 
-    excel_fp = tmp_path / "roster.xlsx"
+    excel_fp = tmp_path / "roster.parquet"
     horizon = 5
 
     out = learn_roster(demand_csv, excel_fp, forecast_csv=forecast_csv, horizon=horizon)
     assert out.exists()
-    roster_df = pd.read_excel(out)
+    roster_df = pd.read_parquet(out)
     assert len(roster_df) == horizon
 
 
@@ -127,7 +127,7 @@ def test_learn_roster_model_load_failure(tmp_path, monkeypatch):
     model_fp = tmp_path / "model.zip"
     model_fp.write_text("x")
 
-    excel_fp = tmp_path / "roster.xlsx"
+    excel_fp = tmp_path / "roster.parquet"
 
     out = learn_roster(
         demand_csv,

--- a/tests/test_rl.py
+++ b/tests/test_rl.py
@@ -40,8 +40,8 @@ def test_learn_roster_forecast_longer(monkeypatch, tmp_path):
     monkeypatch.setattr(rl, "PPO", DummyPPO)
 
     out = rl.learn_roster(
-        demand_fp, tmp_path / "out.xlsx", forecast_csv=fc_fp, shortage_csv=sh_fp
+        demand_fp, tmp_path / "out.parquet", forecast_csv=fc_fp, shortage_csv=sh_fp
     )
     assert out is not None
-    df_out = pd.read_excel(out)
+    df_out = pd.read_parquet(out)
     assert len(df_out) == len(fc_df)


### PR DESCRIPTION
## Summary
- output Parquet instead of Excel in `fairness.py`
- save RL roster results as Parquet
- adjust related tests for Parquet files

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas/numpy)*

------
https://chatgpt.com/codex/tasks/task_e_684951e960008333a1f29aa3590962c8