### PR TITLE
Fix watcher patch call order

### DIFF
--- a/app.py
+++ b/app.py
@@ -140,9 +140,11 @@ def _patch_streamlit_watcher() -> None:
     _lsw.extract_paths = _safe_extract_paths
 
 
+# Call the watcher patch before configuring logging so that any modules
+# imported during setup won't trigger errors.
+_patch_streamlit_watcher()
 # ── ロガー設定 ─────────────────────────────────
 configure_logging()
-_patch_streamlit_watcher()
 log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- ensure the Streamlit watcher patch runs before logging setup

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684953257d1c833389e442c7195b7b7f