### PR TITLE
Enable Parquet in display functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ are automatically imported by `shift_suite/__init__.py`, so you can simply
 - **`leave_analyzer`** – Summarises paid and requested leave days.
 - **`cli_bridge`** – Lightweight CLI for `leave_analyzer` based on CSV input.
 
-The GUI caches the uploaded workbook using `load_excelfile_cached()` with
-`st.cache_resource`, as `pd.ExcelFile` objects cannot be pickled.
+The GUI caches uploaded Excel or Parquet files using `load_data_cached()` with
+`st.cache_data`.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- support caching of Parquet and Excel with `load_data_cached`
- update docs for the new helper
- load Parquet files in `display_shortage_factor_section`
- rewrite `display_heatmap_tab` to use `st.form`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_684953e857f483339388a41f1ecbc56e