### PR TITLE
Fix parquet IO paths

### DIFF
--- a/shift_suite/tasks/anomaly.py
+++ b/shift_suite/tasks/anomaly.py
@@ -14,14 +14,14 @@ from .utils import log, save_df_parquet
 
 
 def detect_anomaly(out_dir: Path, contamination: float = 0.05):
-    hp = out_dir / "heat_ALL.xlsx"
+    hp = out_dir / "heat_ALL.parquet"
     if not hp.exists():
-        log.error(f"[anomaly] heat_ALL.xlsx が見つかりません: {hp}")
+        log.error(f"[anomaly] heat_ALL.parquet が見つかりません: {hp}")
         return None
     try:
-        heat = pd.read_excel(hp, index_col=0)
+        heat = pd.read_parquet(hp)
     except Exception as e:
-        log.error(f"[anomaly] heat_ALL.xlsx の読み込み中にエラー: {e}", exc_info=True)
+        log.error(f"[anomaly] heat_ALL.parquet の読み込み中にエラー: {e}", exc_info=True)
         return None
 
     date_columns = [col for col in heat.columns if col not in SUMMARY5]

--- a/shift_suite/tasks/build_stats.py
+++ b/shift_suite/tasks/build_stats.py
@@ -72,7 +72,7 @@ def build_stats(
     stats_fp = out_dir_path / "stats_error.parquet"
     log.info(f"=== build_stats start (out_dir={out_dir_path}) ===")
 
-    required_files = ["heat_ALL.xlsx"]
+    required_files = ["heat_ALL.parquet"]
     missing = _check_files_exist(out_dir_path, required_files)
     if missing:
         log.error(
@@ -89,14 +89,14 @@ def build_stats(
     estimated_holidays_set: Set[dt.date] = set(holidays or [])
 
     try:
-        heat_all_df = pd.read_excel(out_dir_path / "heat_ALL.xlsx", index_col=0)
-        log.debug(f"heat_ALL.xlsx を読み込みました。Shape: {heat_all_df.shape}")
+        heat_all_df = pd.read_parquet(out_dir_path / "heat_ALL.parquet")
+        log.debug(f"heat_ALL.parquet を読み込みました。Shape: {heat_all_df.shape}")
     except Exception as e:
         log.error(
-            f"heat_ALL.xlsx の読み込み中にエラーが発生しました: {e}", exc_info=True
+            f"heat_ALL.parquet の読み込み中にエラーが発生しました: {e}", exc_info=True
         )
         try:
-            pd.DataFrame({"error": [f"Error reading heat_ALL.xlsx: {e}"]}).to_parquet(
+            pd.DataFrame({"error": [f"Error reading heat_ALL.parquet: {e}"]}).to_parquet(
                 stats_fp,
                 index=False,
             )
@@ -133,7 +133,7 @@ def build_stats(
     ]
     if not date_columns_in_heat:
         log.error(
-            "heat_ALL.xlsx に有効な日付列が見つかりません。統計処理を中止します。"
+            "heat_ALL.parquet に有効な日付列が見つかりません。統計処理を中止します。"
         )
         return
 
@@ -192,7 +192,7 @@ def build_stats(
 
     if "need" not in heat_all_df.columns or "upper" not in heat_all_df.columns:
         log.error(
-            "'need' または 'upper' 列が heat_ALL.xlsx に見つかりません。処理を中止します。"
+            "'need' または 'upper' 列が heat_ALL.parquet に見つかりません。処理を中止します。"
         )
         return
     need_per_timeslot_series_orig = (

--- a/shift_suite/tasks/over_shortage_log.py
+++ b/shift_suite/tasks/over_shortage_log.py
@@ -17,7 +17,7 @@ def list_events(out_dir: Path | str) -> pd.DataFrame:
         if not fp.exists():
             return
         try:
-            df = pd.read_excel(fp, sheet_name=sheet, index_col=0)
+            df = pd.read_parquet(fp)
         except Exception as e:  # noqa: BLE001
             log.warning("Failed to read %s [%s]: %s", fp, sheet, e)
             return
@@ -33,8 +33,8 @@ def list_events(out_dir: Path | str) -> pd.DataFrame:
             long["type"] = kind
             records.append(long)
 
-    _read(out_dir_path / "shortage_time.xlsx", "lack_time", "shortage")
-    _read(out_dir_path / "excess_time.xlsx", "excess_time", "excess")
+    _read(out_dir_path / "shortage_time.parquet", "lack_time", "shortage")
+    _read(out_dir_path / "excess_time.parquet", "excess_time", "excess")
 
     if records:
         return pd.concat(records, ignore_index=True)

--- a/shift_suite/tasks/shortage.py
+++ b/shift_suite/tasks/shortage.py
@@ -54,14 +54,14 @@ def shortage_and_brief(
 
     estimated_holidays_set: Set[dt.date] = set(holidays or [])
 
-    fp_all_heatmap = out_dir_path / "heat_ALL.xlsx"
+    fp_all_heatmap = out_dir_path / "heat_ALL.parquet"
     if not fp_all_heatmap.exists():
-        log.error(f"[shortage] heat_ALL.xlsx が見つかりません: {fp_all_heatmap}")
+        log.error(f"[shortage] heat_ALL.parquet が見つかりません: {fp_all_heatmap}")
         return None
     try:
-        heat_all_df = pd.read_excel(fp_all_heatmap, index_col=0)
+        heat_all_df = pd.read_parquet(fp_all_heatmap)
     except Exception as e:
-        log.error(f"[shortage] heat_ALL.xlsx の読み込み中にエラー: {e}", exc_info=True)
+        log.error(f"[shortage] heat_ALL.parquet の読み込み中にエラー: {e}", exc_info=True)
         return None
 
     date_columns_in_heat_all = [
@@ -936,18 +936,18 @@ def _summary_by_period(df: pd.DataFrame, *, period: str) -> pd.DataFrame:
 
 
 def weekday_timeslot_summary(
-    out_dir: Path | str, *, excel: str = "shortage_time.xlsx"
+    out_dir: Path | str, *, excel: str = "shortage_time.parquet"
 ) -> pd.DataFrame:
     """Return average shortage counts by weekday and time slot."""
 
-    df = pd.read_excel(Path(out_dir) / excel, index_col=0)
+    df = pd.read_parquet(Path(out_dir) / excel)
     return _summary_by_period(df, period="weekday")
 
 
 def monthperiod_timeslot_summary(
-    out_dir: Path | str, *, excel: str = "shortage_time.xlsx"
+    out_dir: Path | str, *, excel: str = "shortage_time.parquet"
 ) -> pd.DataFrame:
     """Return average shortage counts by month period and time slot."""
 
-    df = pd.read_excel(Path(out_dir) / excel, index_col=0)
+    df = pd.read_parquet(Path(out_dir) / excel)
     return _summary_by_period(df, period="month_period")

--- a/tests/test_excess_analysis.py
+++ b/tests/test_excess_analysis.py
@@ -16,14 +16,14 @@ def _create_heatmap_with_upper(out_dir: Path) -> None:
         },
         index=labels,
     )
-    df.to_excel(out_dir / "heat_ALL.xlsx")
+    df.to_parquet(out_dir / "heat_ALL.parquet")
 
 
 def test_excess_output(tmp_path: Path) -> None:
     _create_heatmap_with_upper(tmp_path)
     shortage_and_brief(tmp_path, slot=30)
-    excess_df = pd.read_excel(tmp_path / "excess_time.xlsx", index_col=0)
-    shortage_df = pd.read_excel(tmp_path / "shortage_time.xlsx", index_col=0)
+    excess_df = pd.read_parquet(tmp_path / "excess_time.parquet")
+    shortage_df = pd.read_parquet(tmp_path / "shortage_time.parquet")
     assert excess_df.iloc[0, 0] == 1
     assert excess_df.iloc[1, 0] == 0
     assert shortage_df.iloc[0, 0] == 0

--- a/tests/test_optimization_metrics.py
+++ b/tests/test_optimization_metrics.py
@@ -14,15 +14,15 @@ def _create_heatmap(out_dir: Path) -> None:
         },
         index=labels,
     )
-    df.to_excel(out_dir / "heat_ALL.xlsx")
+    df.to_parquet(out_dir / "heat_ALL.parquet")
 
 
 def test_optimization_outputs(tmp_path: Path) -> None:
     _create_heatmap(tmp_path)
     shortage_and_brief(tmp_path, slot=30)
-    surplus_df = pd.read_excel(tmp_path / "surplus_vs_need_time.xlsx", index_col=0)
-    margin_df = pd.read_excel(tmp_path / "margin_vs_upper_time.xlsx", index_col=0)
-    score_df = pd.read_excel(tmp_path / "optimization_score_time.xlsx", index_col=0)
+    surplus_df = pd.read_parquet(tmp_path / "surplus_vs_need_time.parquet")
+    margin_df = pd.read_parquet(tmp_path / "margin_vs_upper_time.parquet")
+    score_df = pd.read_parquet(tmp_path / "optimization_score_time.parquet")
 
     assert surplus_df.iloc[0, 0] == 1
     assert surplus_df.iloc[2, 0] == 3

--- a/tests/test_shortage_employment.py
+++ b/tests/test_shortage_employment.py
@@ -9,7 +9,7 @@ from shift_suite.tasks.utils import gen_labels
 def _create_heatmaps(out_dir: Path) -> None:
     labels = gen_labels(30)[:2]
     df_all = pd.DataFrame({"need": [1, 1], "2024-06-01": [1, 1]}, index=labels)
-    df_all.to_excel(out_dir / "heat_ALL.xlsx")
+    df_all.to_parquet(out_dir / "heat_ALL.parquet")
     df_emp = pd.DataFrame({"need": [1, 1], "2024-06-01": [1, 1]}, index=labels)
     df_emp.to_excel(out_dir / "heat_emp_Fulltime.xlsx")
 

--- a/tests/test_shortage_period_summary.py
+++ b/tests/test_shortage_period_summary.py
@@ -21,7 +21,7 @@ def _create_heatmap(out_dir: Path) -> None:
         },
         index=labels,
     )
-    df.to_excel(out_dir / "heat_ALL.xlsx")
+    df.to_parquet(out_dir / "heat_ALL.parquet")
 
 
 def test_weekday_timeslot_summary(tmp_path: Path) -> None:

--- a/tests/test_shortage_slider.py
+++ b/tests/test_shortage_slider.py
@@ -7,10 +7,10 @@ from shift_suite.tasks.utils import gen_labels
 
 
 def _create_sample_heatmap(out_dir: Path) -> None:
-    """Create a minimal heat_ALL.xlsx for testing."""
+    """Create a minimal heat_ALL.parquet for testing."""
     labels = gen_labels(30)[:2]  # just a couple of slots
     df = pd.DataFrame({"need": [1, 1], "2024-06-01": [0, 0]}, index=labels)
-    df.to_excel(out_dir / "heat_ALL.xlsx")
+    df.to_parquet(out_dir / "heat_ALL.parquet")
 
 
 def test_shortage_time_unchanged_by_slider(tmp_path: Path) -> None:
@@ -18,14 +18,14 @@ def test_shortage_time_unchanged_by_slider(tmp_path: Path) -> None:
 
     Running ``shortage_and_brief`` with its default parameters and with
     an alternate value simulating a slider (empty ``holidays`` list) should
-    produce identical ``shortage_time.xlsx`` files.
+    produce identical ``shortage_time.parquet`` files.
     """
     _create_sample_heatmap(tmp_path)
 
     shortage_and_brief(tmp_path, slot=30)
-    df_default = pd.read_excel(tmp_path / "shortage_time.xlsx", index_col=0)
+    df_default = pd.read_parquet(tmp_path / "shortage_time.parquet")
 
     shortage_and_brief(tmp_path, slot=30, holidays=[])
-    df_slider0 = pd.read_excel(tmp_path / "shortage_time.xlsx", index_col=0)
+    df_slider0 = pd.read_parquet(tmp_path / "shortage_time.parquet")
 
     pd.testing.assert_frame_equal(df_default, df_slider0)


### PR DESCRIPTION
## Summary
- load heatmaps from `.parquet` instead of `.xlsx`
- update shortage summaries to read parquet files
- update log utilities to read parquet
- adjust build_stats to use parquet input
- fix related unit tests to use parquet fixtures

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68495844b4388333bb40723a81514a8c