### PR TITLE
Fix file format handling from Excel to Parquet

### DIFF
--- a/app.py
+++ b/app.py
@@ -1521,8 +1521,8 @@ if run_button_clicked:
                             )
                         elif opt_module_name_exec_run == "Need forecast":
                             demand_csv_exec_run_fc = out_dir_exec / "demand_series.csv"
-                            forecast_xls_exec_run_fc = out_dir_exec / "forecast.xlsx"
-                            heat_all_for_fc_exec_run_fc = out_dir_exec / "heat_ALL.xlsx"
+                            forecast_xls_exec_run_fc = out_dir_exec / "forecast.parquet"  # 出力もparquetに
+                            heat_all_for_fc_exec_run_fc = out_dir_exec / "heat_ALL.parquet"  # 入力をparquetに
                             if not heat_all_for_fc_exec_run_fc.exists():
                                 st.warning(
                                     _("Need forecast")

--- a/shift_suite/tasks/forecast.py
+++ b/shift_suite/tasks/forecast.py
@@ -123,7 +123,7 @@ def build_demand_series(
     raise_on_empty: bool = True,
     leave_csv: Path | None = None,
 ) -> Path:
-    """heat_ALL.xlsx → 需要系列 CSV(ds,y) を生成
+    """heat_ALL.parquet → 需要系列 CSV(ds,y) を生成
 
     Parameters
     ----------
@@ -140,7 +140,11 @@ def build_demand_series(
         休暇取得数を ``leave_…`` 列として付与する
     """
     log.info("[forecast] build_demand_series start")
-    heat = pd.read_excel(heat_xlsx, index_col=0)
+    # heat_xlsx が .xlsx で終わる場合と .parquet で終わる場合の両方に対応
+    if str(heat_xlsx).endswith(".xlsx"):
+        heat = pd.read_excel(heat_xlsx, index_col=0)
+    else:
+        heat = pd.read_parquet(heat_xlsx)
 
     date_map = _extract_date_columns(heat)
     if not date_map:

--- a/shift_suite/tasks/merge_shortage_leave.py
+++ b/shift_suite/tasks/merge_shortage_leave.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 def merge_shortage_leave(
     out_dir: Path | str,
-    shortage_excel: str | Path = "shortage_time.xlsx",
+    shortage_excel: str | Path = "shortage_time.parquet",  # .xlsx から .parquet に変更
     leave_csv: str | Path = "leave_analysis.csv",
     out_csv: str | Path = "shortage_leave.csv",
     *,
@@ -42,7 +42,7 @@ def merge_shortage_leave(
     if not leave_fp.exists():
         raise FileNotFoundError(leave_fp)
 
-    lack_df = pd.read_excel(shortage_fp, index_col=0)
+    lack_df = pd.read_parquet(shortage_fp)  # read_excel から read_parquet に変更
     lack_long = (
         lack_df.reset_index()
         .melt(id_vars=lack_df.index.name, var_name="date", value_name="lack")

--- a/shift_suite/tasks/ppt.py
+++ b/shift_suite/tasks/ppt.py
@@ -19,7 +19,7 @@ def _add_shortage_slide(prs: Presentation, shortage_fp: Path) -> None:
     """Add a bar chart slide summarising shortage by role."""
     import matplotlib.pyplot as plt
 
-    df = pd.read_excel(shortage_fp, sheet_name="role_summary")
+    df = pd.read_parquet(shortage_fp)  # read_excel から read_parquet に変更
     if df.empty:
         return
 
@@ -42,7 +42,7 @@ def _add_cost_slide(prs: Presentation, cost_fp: Path) -> None:
     """Add a slide showing cost simulations."""
     import matplotlib.pyplot as plt
 
-    df = pd.read_excel(cost_fp, index_col=0)
+    df = pd.read_parquet(cost_fp)  # read_excel から read_parquet に変更
     if df.empty:
         return
 
@@ -78,8 +78,8 @@ def build_ppt(out_dir: Path) -> Path:
         subtitle = slide.placeholders[1]
         subtitle.text = str(out_dir)
 
-    shortage_fp = out_dir / "shortage_role.xlsx"
-    cost_fp = out_dir / "cost_benefit.xlsx"
+    shortage_fp = out_dir / "shortage_role_summary.parquet"  # ファイル名を .parquet に変更
+    cost_fp = out_dir / "cost_benefit.parquet"  # ファイル名を .parquet に変更
 
     if shortage_fp.exists():
         _add_shortage_slide(prs, shortage_fp)


### PR DESCRIPTION
## Summary
- handle `.parquet` input in `build_demand_series`
- adjust Need forecast paths to use parquet files
- read shortage-time parquet in `merge_shortage_leave`
- update PPT generator to read parquet outputs

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68495b420218833387631b3cf67e370a