### PR TITLE
Switch heat_ALL.xlsx references to parquet

### DIFF
--- a/app.py
+++ b/app.py
@@ -1138,8 +1138,8 @@ if run_button_clicked:
                 if _("基準乖離分析") in param_ext_opts and param_need_calc_method == _(
                     "人員配置基準に基づき設定する"
                 ):
-                    heat_all_df = pd.read_excel(
-                        out_dir_exec / "heat_ALL.xlsx", index_col=0
+                    heat_all_df = pd.read_parquet(
+                        out_dir_exec / "heat_ALL.parquet"
                     )
                     gap_results = analyze_standards_gap(heat_all_df, param_need_manual)
                     st.session_state.gap_analysis_results = gap_results

--- a/dash_app.py
+++ b/dash_app.py
@@ -42,7 +42,7 @@ def drop_summary_cols(df: pd.DataFrame) -> pd.DataFrame:
 
 # ────────────────── 2. データロード (エラーハンドリングを少し追加) ──────────────────
 try:
-    heat_all_df = pd.read_excel(DATA_DIR / "heat_ALL.xlsx", index_col=0)
+    heat_all_df = pd.read_parquet(DATA_DIR / "heat_ALL.parquet")
     need_series_for_ratio = heat_all_df["need"].replace(0, np.nan)
 
     heat_staff_data = drop_summary_cols(heat_all_df)
@@ -97,7 +97,7 @@ try:
 except FileNotFoundError:
     log.error(
         "エラー: %s が見つかりません。先にstreamlit app.pyで解析を実行してください。",
-        DATA_DIR / "heat_ALL.xlsx",
+        DATA_DIR / "heat_ALL.parquet",
     )
     # Dashアプリ起動前に終了させるか、エラーメッセージを表示するコンポーネントを返す
     heat_all_df = pd.DataFrame()  # 空のDFで初期化
@@ -184,7 +184,7 @@ def page_heat():
                 html.H4(_("Heatmap Data Not Found")),
                 html.P(
                     _(
-                        "Please run the analysis via the Streamlit app first and ensure 'out/heat_ALL.xlsx' exists."
+                        "Please run the analysis via the Streamlit app first and ensure 'out/heat_ALL.parquet' exists."
                     )
                 ),
             ]

--- a/shift_suite/tasks/benchmark.py
+++ b/shift_suite/tasks/benchmark.py
@@ -23,10 +23,10 @@ def _meta(p: Path) -> dict:
 
 
 def _kpi(out_dir: Path) -> dict:
-    heat_p = out_dir / "heat_ALL.xlsx"
+    heat_p = out_dir / "heat_ALL.parquet"
     if not heat_p.exists():
         return {}
-    heat = pd.read_excel(heat_p, index_col=0)
+    heat = pd.read_parquet(heat_p)
     total_h = heat.sum().sum()
     need = derive_min_staff(heat, "mean-1s")
     lack_h = heat.sub(need, axis=0).clip(lower=0).sum().sum()

--- a/shift_suite/tasks/dashboard.py
+++ b/shift_suite/tasks/dashboard.py
@@ -177,10 +177,10 @@ def load_leave_results_from_dir(data_dir: Path) -> dict:
     daily_df = results.get("daily_summary")
 
     if "staff_balance_daily" not in results and _valid_df(daily_df):
-        heat_fp = data_dir / "heat_ALL.xlsx"
+        heat_fp = data_dir / "heat_ALL.parquet"
         if heat_fp.exists():
             try:
-                heat = pd.read_excel(heat_fp, index_col=0)
+                heat = pd.read_parquet(heat_fp)
                 date_cols = [c for c in heat.columns if c not in SUMMARY5_CONST]
                 total_staff = (
                     (heat[date_cols] > 0)


### PR DESCRIPTION
## Summary
- read `heat_ALL.parquet` instead of `heat_ALL.xlsx`
- update fallback messages for missing data

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas and numpy)*

------
https://chatgpt.com/codex/tasks/task_e_684a0c428ca08333be4f666e88033318