### PR TITLE
Fix hire_plan column handling

### DIFF
--- a/shift_suite/tasks/cost_benefit.py
+++ b/shift_suite/tasks/cost_benefit.py
@@ -1,7 +1,7 @@
 """
 cost_benefit.py ── “採用 / 派遣 / 漏れ (罰金)” コストを試算するユーティリティ
 -------------------------------------------------------------------
-入力 : shortage_role.xlsx（不足 h）   hire_plan.xlsx（hire_need）
+入力 : shortage_role.xlsx（不足 h）   hire_plan.xlsx（hire_need または hire_fte）
 出力 : cost_benefit.xlsx（シナリオ別比較表）
 呼出 : analyze_cost_benefit(out_dir            = Path,
                             wage_direct        = 1500,
@@ -35,6 +35,7 @@ def analyze_cost_benefit(
     ----------
     out_dir : Path
         shortage_role.xlsx / hire_plan.xlsx が置かれている out フォルダ
+        hire_plan.parquet には hire_need あるいは hire_fte 列が必要
     wage_direct : int, default 1500
         正社員（常勤換算）1 h あたりの人件費
     wage_temp : int, default 2200
@@ -61,7 +62,12 @@ def analyze_cost_benefit(
     plan = pd.read_parquet(hire_fp)
 
     lack_h_total = lack["lack_h"].sum()
-    hire_need_total = plan["hire_need"].sum()
+    if "hire_need" in plan.columns:
+        hire_need_total = plan["hire_need"].sum()
+    elif "hire_fte" in plan.columns:
+        hire_need_total = plan["hire_fte"].sum()
+    else:
+        raise KeyError("hire_plan.parquet missing required column 'hire_need' or 'hire_fte'")
 
     # --- シナリオ試算 ----------------------------------------------------------
     scenarios = {}

--- a/tests/test_cost_benefit.py
+++ b/tests/test_cost_benefit.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+import pandas as pd
+
+from shift_suite.tasks.cost_benefit import analyze_cost_benefit
+
+
+def _create_base_files(tmp_path: Path):
+    df_lack = pd.DataFrame({"role": ["A"], "lack_h": [10]})
+    df_lack.to_parquet(tmp_path / "shortage_role_summary.parquet", index=False)
+
+
+def test_analyze_cost_benefit_with_hire_need(tmp_path: Path):
+    _create_base_files(tmp_path)
+    df_plan = pd.DataFrame({"role": ["A"], "hire_need": [2]})
+    df_plan.to_parquet(tmp_path / "hire_plan.parquet", index=False)
+
+    result = analyze_cost_benefit(tmp_path)
+    assert "Cost_JPY" in result.columns
+
+
+def test_analyze_cost_benefit_with_hire_fte(tmp_path: Path):
+    _create_base_files(tmp_path)
+    df_plan = pd.DataFrame({"role": ["A"], "hire_fte": [2]})
+    df_plan.to_parquet(tmp_path / "hire_plan.parquet", index=False)
+
+    result = analyze_cost_benefit(tmp_path)
+    assert "Cost_JPY" in result.columns
+
+


### PR DESCRIPTION
## Summary
- support `hire_fte` in cost/benefit calculator
- test cost/benefit with both `hire_need` and `hire_fte`

## Testing
- `ruff check .`
- `pytest -q` *(fails: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a3760761483339ccc097c721ab70b