### PR TITLE
Fix analysis flag handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -1828,7 +1828,6 @@ if run_button_clicked:
             "low_staff_load_results": st.session_state.low_staff_load_results,
         }
 
-st.session_state.analysis_done = True
 
 # 分析が完了していて、かつ表示用データがまだ読み込まれていない場合に一度だけ実行
 if st.session_state.get("analysis_done") and "display_data" not in st.session_state:


### PR DESCRIPTION
## Summary
- prevent `analysis_done` from always being set to `True`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684a3a1a6d8c8333a017aa485a28c9a3