### PR TITLE
Update README testing notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ Install the dependencies first:
 ./setup.sh  # or pip install -r requirements.txt
 ```
 
+Running the tests without installing these packages will result in import
+errors (for example ``pandas`` and ``numpy`` will be missing). Ensure the setup
+command completes successfully before invoking ``pytest``.
+
 Then execute the test suite with:
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify that missing dependencies cause import errors if tests are run before `setup.sh`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_684aa3081b888333a602350741142cbf