### PR TITLE
Fix dash app heatmap and analytics

### DIFF
--- a/app.py
+++ b/app.py
@@ -1399,6 +1399,9 @@ if run_button_clicked:
                     slot_minutes=param_slot,
                     year_month_cell_location=param_year_month_cell,
                 )
+                if wt_df is not None and not wt_df.empty:
+                    wt_df.to_parquet(out_dir_exec / "work_patterns.parquet", index=False)
+                    log.info("勤務区分情報を work_patterns.parquet に保存しました。")
                 parquet_fp = out_dir_exec / "intermediate_data.parquet"
                 long_df.to_parquet(parquet_fp)
                 st.session_state["intermediate_parquet_path"] = str(parquet_fp)


### PR DESCRIPTION
## Summary
- split role and employment dropdowns in heatmap tab
- load additional CSV/Parquet data and work pattern info
- extend leave and fairness analysis tabs
- fix fatigue tab plotting
- update hire plan simulation and save work pattern parquet

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684bbd49e2e08333a6b78fc7742aa1c1