### PR TITLE
Fix daily cost export and loading

### DIFF
--- a/app.py
+++ b/app.py
@@ -2022,6 +2022,9 @@ if run_button_clicked:
                     daily_cost_df.to_excel(
                         out_dir_exec / "daily_cost.xlsx", index=False
                     )
+                    daily_cost_df.to_parquet(
+                        out_dir_exec / "daily_cost.parquet", index=False
+                    )
                 except Exception as e_cost:
                     log.warning(f"daily cost calculation failed: {e_cost}")
 

--- a/dash_app.py
+++ b/dash_app.py
@@ -925,6 +925,10 @@ def process_upload(contents, filename):
                 df = safe_read_parquet(data_dir / file)
                 if not df.empty:
                     DATA_STORE[file.replace('.parquet', '')] = df
+            elif file == 'daily_cost.parquet' and (data_dir / 'daily_cost.xlsx').exists():
+                df = safe_read_excel(data_dir / 'daily_cost.xlsx')
+                if not df.empty:
+                    DATA_STORE['daily_cost'] = df
 
         # CSVファイル
         csv_files = [


### PR DESCRIPTION
## Summary
- export daily cost results to parquet in the main app
- load `daily_cost.xlsx` as a fallback in the Dash viewer

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684bcb4bba7483339ae9cf34239fd4de