### PR TITLE
Add dependency note for statsmodels

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ The GUI caches uploaded Excel or Parquet files using `load_data_cached()` with
    pip install -r requirements.txt
    ```
 
+   This installs optional packages like `statsmodels`.  If you skip
+   this step you may see errors such as
+   `ModuleNotFoundError: No module named 'statsmodels'` when running
+   `app.py`.
+
    The `requirements.txt` file pins `scikit-learn` to `1.4.1.post1` for
    compatibility with Python 3.12.
    It also installs `streamlit-plotly-events` so the leave analysis charts


### PR DESCRIPTION
## Summary
- add note that `pip install -r requirements.txt` installs optional packages like `statsmodels`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685229adc4988333965b56f648300b36