### PR TITLE
Fix reading/writing formats and groupby options

### DIFF
--- a/app.py
+++ b/app.py
@@ -1812,7 +1812,9 @@ if run_button_clicked:
 
                                 # Also generate shortage_leave.xlsx for the Shortage tab
                                 merge_shortage_leave(out_dir_exec, leave_csv=leave_csv)
-                            except Exception as e_save:
+                            except FileNotFoundError:
+                                log.warning("shortage_time.parquet not found for merge, skipping.")
+                            except Exception as e_save:  # noqa: BLE001
                                 log.warning(
                                     f"leave_analysis.csv 書き出しまたは shortage_leave.xlsx 生成中にエラー: {e_save}"
                                 )

--- a/shift_suite/tasks/leave_analyzer.py
+++ b/shift_suite/tasks/leave_analyzer.py
@@ -187,9 +187,7 @@ def summarize_leave_by_day_count(
         return pd.DataFrame()
 
     summary = (
-        df_to_agg.groupby(["period_unit", "leave_type"], observed=False)[
-            "leave_day_flag"
-        ]
+        df_to_agg.groupby(["period_unit", "leave_type"])["leave_day_flag"]
         .sum()
         .reset_index(name="total_leave_days")
     )
@@ -198,7 +196,7 @@ def summarize_leave_by_day_count(
     unique_dates = (
         df_to_agg[["period_unit", "date"]]
         .drop_duplicates()
-        .groupby("period_unit")
+        .groupby("period_unit", observed=False)
         .size()
         .reset_index(name="num_days_in_period_unit")
     )

--- a/shift_suite/tasks/shortage.py
+++ b/shift_suite/tasks/shortage.py
@@ -802,28 +802,28 @@ def shortage_and_brief(
 def merge_shortage_leave(
     out_dir: Path | str,
     *,
-    shortage_xlsx: str | Path = "shortage_time.xlsx",
+    shortage_xlsx: str | Path = "shortage_time.parquet",
     leave_csv: str | Path = "leave_analysis.csv",
-    out_excel: str | Path = "shortage_leave.parquet",
+    out_excel: str | Path = "shortage_leave.csv",
 ) -> Path | None:
-    """Combine shortage_time.xlsx with leave counts.
+    """Combine shortage_time.parquet with leave counts.
 
     Parameters
     ----------
     out_dir:
         Directory containing shortage and leave files.
     shortage_xlsx:
-        Name of ``shortage_time.xlsx``. Must exist under ``out_dir``.
+        Name of ``shortage_time.parquet``. Must exist under ``out_dir``.
     leave_csv:
         Optional ``leave_analysis.csv`` with columns ``date`` and
         ``total_leave_days``. If missing, leave counts are treated as ``0``.
     out_excel:
-        Output parquet filename.
+        Output CSV filename.
 
     Returns
     -------
     Path | None
-        Path to the saved Excel file or ``None`` if shortage data missing.
+        Path to the saved CSV file or ``None`` if shortage data missing.
     """
 
     out_dir_path = Path(out_dir)
@@ -833,7 +833,7 @@ def merge_shortage_leave(
         return None
 
     try:
-        shortage_df = pd.read_excel(shortage_fp, index_col=0)
+        shortage_df = pd.read_parquet(shortage_fp)
     except Exception as e:
         log.error(f"[shortage] failed to read {shortage_fp}: {e}")
         return None
@@ -868,7 +868,8 @@ def merge_shortage_leave(
         lower=0
     )
 
-    out_fp = save_df_parquet(long_df, out_dir_path / out_excel, index=False)
+    out_fp = out_dir_path / out_excel
+    long_df.to_csv(out_fp, index=False)
     return out_fp
 
 


### PR DESCRIPTION
## Summary
- read shortage_time from Parquet in `merge_shortage_leave` and export CSV
- avoid pandas observed warning in `summarize_leave_by_day_count`
- handle missing `shortage_time.parquet` in app

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas/numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68582540f7908333be746b0b789308ae