### PR TITLE
Fix heatmap empty plot case in Dash app

### DIFF
--- a/dash_app.py
+++ b/dash_app.py
@@ -1470,7 +1470,8 @@ def update_comparison_heatmaps(role1, emp1, role2, emp2):
             time_labels = gen_labels(30)
             all_dates = sorted(aggregated_df['date_lbl'].unique())
             empty_heatmap = pd.DataFrame(index=time_labels, columns=all_dates).fillna(0)
-            return generate_heatmap_figure(empty_heatmap, f"{title} (勤務データなし)")
+            fig_empty = generate_heatmap_figure(empty_heatmap, f"{title} (勤務データなし)")
+            return dcc.Graph(figure=fig_empty)
 
         dynamic_heatmap_df = filtered_df.pivot_table(
             index='time',


### PR DESCRIPTION
## Summary
- handle empty filtered dataframe in `update_comparison_heatmaps` by wrapping the generated figure in `dcc.Graph`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6858f153a3ec8333bb3cc618a2f6c365