### PR TITLE
Fix holiday exclusion in heatmap need calc

### DIFF
--- a/shift_suite/tasks/heatmap.py
+++ b/shift_suite/tasks/heatmap.py
@@ -515,6 +515,8 @@ def build_heatmap(
         need_stat_method if need_stat_method is not None else need_statistic_method
     )
 
+    final_holidays_to_use = holidays_set.union(estimated_holidays_set)
+
     dow_need_pattern_df = calculate_pattern_based_need(
         actual_staff_for_need_input,
         ref_start_date_for_need,
@@ -523,7 +525,7 @@ def build_heatmap(
         need_remove_outliers,
         need_iqr_multiplier,
         slot_minutes_for_empty=slot_minutes,
-        holidays=holidays_set,
+        holidays=final_holidays_to_use,
         adjustment_factor=need_adjustment_factor,
     )
 


### PR DESCRIPTION
## Summary
- ensure automatically estimated holidays are excluded when calculating need

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68591290f7b48333a7e4a33f99ba5c32