### PR TITLE
Fix weekday shortage calculation

### DIFF
--- a/tests/test_excess_analysis.py
+++ b/tests/test_excess_analysis.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pandas as pd
 
 from shift_suite.tasks.shortage import shortage_and_brief
-from shift_suite.tasks.utils import gen_labels
+from shift_suite.tasks.utils import gen_labels, write_meta
 
 
 def _create_heatmap_with_upper(out_dir: Path) -> None:
@@ -17,6 +17,14 @@ def _create_heatmap_with_upper(out_dir: Path) -> None:
         index=labels,
     )
     df.to_parquet(out_dir / "heat_ALL.parquet")
+    write_meta(
+        out_dir / "heatmap.meta.json",
+        slot=30,
+        dates=["2024-06-01"],
+        summary_columns=["need", "upper", "staff", "lack", "excess"],
+        estimated_holidays=[],
+        dow_need_pattern=[{"time": t, **{str(i): 1 for i in range(7)}} for t in labels],
+    )
 
 
 def test_excess_output(tmp_path: Path) -> None:

--- a/tests/test_optimization_metrics.py
+++ b/tests/test_optimization_metrics.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import pandas as pd
 from shift_suite.tasks.shortage import shortage_and_brief
-from shift_suite.tasks.utils import gen_labels
+from shift_suite.tasks.utils import gen_labels, write_meta
 
 
 def _create_heatmap(out_dir: Path) -> None:
@@ -15,6 +15,14 @@ def _create_heatmap(out_dir: Path) -> None:
         index=labels,
     )
     df.to_parquet(out_dir / "heat_ALL.parquet")
+    write_meta(
+        out_dir / "heatmap.meta.json",
+        slot=30,
+        dates=["2024-06-01"],
+        summary_columns=["need", "upper", "staff", "lack", "excess"],
+        estimated_holidays=[],
+        dow_need_pattern=[{"time": t, **{str(i): 1 for i in range(7)}} for t in labels],
+    )
 
 
 def test_optimization_outputs(tmp_path: Path) -> None:

--- a/tests/test_shortage_employment.py
+++ b/tests/test_shortage_employment.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pandas as pd
 
 from shift_suite.tasks.shortage import shortage_and_brief
-from shift_suite.tasks.utils import gen_labels
+from shift_suite.tasks.utils import gen_labels, write_meta
 
 
 def _create_heatmaps(out_dir: Path) -> None:
@@ -12,6 +12,15 @@ def _create_heatmaps(out_dir: Path) -> None:
     df_all.to_parquet(out_dir / "heat_ALL.parquet")
     df_emp = pd.DataFrame({"need": [1, 1], "2024-06-01": [1, 1]}, index=labels)
     df_emp.to_excel(out_dir / "heat_emp_Fulltime.xlsx")
+    write_meta(
+        out_dir / "heatmap.meta.json",
+        slot=30,
+        dates=["2024-06-01"],
+        summary_columns=["need", "upper", "staff", "lack", "excess"],
+        estimated_holidays=[],
+        employments=["Fulltime"],
+        dow_need_pattern=[{"time": t, **{str(i): 1 for i in range(7)}} for t in labels],
+    )
 
 
 def test_shortage_employment_output(tmp_path: Path) -> None:

--- a/tests/test_shortage_period_summary.py
+++ b/tests/test_shortage_period_summary.py
@@ -7,7 +7,7 @@ from shift_suite.tasks.shortage import (
     weekday_timeslot_summary,
     monthperiod_timeslot_summary,
 )
-from shift_suite.tasks.utils import gen_labels
+from shift_suite.tasks.utils import gen_labels, write_meta
 
 
 def _create_heatmap(out_dir: Path) -> None:
@@ -22,6 +22,14 @@ def _create_heatmap(out_dir: Path) -> None:
         index=labels,
     )
     df.to_parquet(out_dir / "heat_ALL.parquet")
+    write_meta(
+        out_dir / "heatmap.meta.json",
+        slot=30,
+        dates=["2024-06-01", "2024-06-11", "2024-06-21"],
+        summary_columns=["need", "upper", "staff", "lack", "excess"],
+        estimated_holidays=[],
+        dow_need_pattern=[{"time": t, **{str(i): 1 for i in range(7)}} for t in labels],
+    )
 
 
 def test_weekday_timeslot_summary(tmp_path: Path) -> None:

--- a/tests/test_shortage_slider.py
+++ b/tests/test_shortage_slider.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pandas as pd
 
 from shift_suite.tasks.shortage import shortage_and_brief
-from shift_suite.tasks.utils import gen_labels
+from shift_suite.tasks.utils import gen_labels, write_meta
 
 
 def _create_sample_heatmap(out_dir: Path) -> None:
@@ -11,6 +11,14 @@ def _create_sample_heatmap(out_dir: Path) -> None:
     labels = gen_labels(30)[:2]  # just a couple of slots
     df = pd.DataFrame({"need": [1, 1], "2024-06-01": [0, 0]}, index=labels)
     df.to_parquet(out_dir / "heat_ALL.parquet")
+    write_meta(
+        out_dir / "heatmap.meta.json",
+        slot=30,
+        dates=["2024-06-01"],
+        summary_columns=["need", "upper", "staff", "lack", "excess"],
+        estimated_holidays=[],
+        dow_need_pattern=[{"time": t, **{str(i): 1 for i in range(7)}} for t in labels],
+    )
 
 
 def test_shortage_time_unchanged_by_slider(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- compute shortage summary using per-day needs
- derive daily need from heatmap meta info
- update tests with sample meta files

## Testing
- `ruff check .`
- `pytest -q` *(fails: pandas/numpy not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a01f88de08333a4752d017cec4590