### PR TITLE
Fix heatmap gaps and shortage logic

### DIFF
--- a/shift_suite/tasks/heatmap.py
+++ b/shift_suite/tasks/heatmap.py
@@ -484,6 +484,11 @@ def build_heatmap(
                 .reindex(index=time_index_labels, fill_value=0)
             )
 
+    # 欠落している日付列を0で補完
+    pivot_data_all_actual_staff = pivot_data_all_actual_staff.reindex(
+        columns=all_date_labels_in_period_str, fill_value=0
+    )
+
     actual_staff_for_need_input = pivot_data_all_actual_staff.copy()
     if not actual_staff_for_need_input.empty:
         new_column_map_for_need_input = {}


### PR DESCRIPTION
## Summary
- prevent missing dates in heatmap tables
- default need to 0 when weekday pattern is missing
- robust index handling in shortage summaries

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685a10916524833389bf4a5d58f3c353