### PR TITLE
Improve blueprint analysis

### DIFF
--- a/dash_app.py
+++ b/dash_app.py
@@ -1055,19 +1055,50 @@ def create_team_analysis_tab() -> html.Div:
 
 
 def create_blueprint_analysis_tab() -> html.Div:
-    """シフト作成ブループリント分析タブを作成"""
+    """シフト作成ブループリント分析タブを作成（改良版）"""
     return html.Div([
-        html.H3("シフト作成プロセスの\u300c暗黙知\u300d分析"),
+        html.H3("シフト作成プロセスの\u300c暗黙知\u300d分析", style={'marginBottom': '20px'}),
         html.P(
-            "過去の質の高いシフトを分析し、熟練者が無意識に行っている\u300cシフトの組み方のセオリー\u300dを抽出します。",
+            "過去のシフトデータから、熟練者が無意識に行っている\u300cシフトの組み方のセオリー\u300dを6つの観点から分析し、抽出します。",
+            style={'marginBottom': '10px'}
         ),
+
+        # 分析観点の説明
+        html.Details([
+            html.Summary('📊 分析の6つの観点（クリックで詳細）', style={'cursor': 'pointer', 'fontWeight': 'bold'}),
+            html.Div([
+                html.Ul([
+                    html.Li("🤝 スキル相性: 誰と誰を組ませると上手くいくか、逆に避けているか"),
+                    html.Li("⚖️ 負荷分散戦略: 繁忙時間帯にどんな戦略で人を配置しているか"),
+                    html.Li("👤 個人配慮: 特定職員の個人事情への配慮パターン"),
+                    html.Li("🔄 ローテーション: 公平性を保つための複雑なローテーションルール"),
+                    html.Li("🚨 リスク回避: トラブル防止のための暗黙の配置ルール"),
+                    html.Li("📅 時系列戦略: 月初・月末、曜日による配置戦略の変化"),
+                ])
+            ], style={'padding': '10px', 'backgroundColor': '#f0f0f0', 'borderRadius': '5px', 'marginTop': '10px'})
+        ], style={'marginBottom': '20px'}),
+
         html.Button(
             "ブループリントを生成",
             id="generate-blueprint-button",
             n_clicks=0,
-            style={"marginTop": "10px", "marginBottom": "20px"},
+            style={
+                "marginTop": "10px",
+                "marginBottom": "20px",
+                "padding": "10px 30px",
+                "fontSize": "16px",
+                "backgroundColor": "#1f77b4",
+                "color": "white",
+                "border": "none",
+                "borderRadius": "5px",
+                "cursor": "pointer"
+            },
         ),
-        dcc.Loading(children=html.Div(id="blueprint-analysis-content")),
+        dcc.Loading(
+            id="loading-blueprint",
+            type="default",
+            children=html.Div(id="blueprint-analysis-content")
+        ),
     ])
 
 # --- メインレイアウト ---
@@ -2068,6 +2099,12 @@ def update_blueprint_analysis_content(n_clicks):
 
     long_df = data_get('long_df', pd.DataFrame())
 
+    if long_df.empty:
+        return html.Div([
+            html.H4("エラー", style={'color': 'red'}),
+            html.P("分析に必要な勤務データが見つかりません。")
+        ])
+
     # 新しい分析関数を呼び出す
     blueprint_data = create_blueprint_list(long_df)
 
@@ -2079,24 +2116,140 @@ def update_blueprint_analysis_content(n_clicks):
 
     # --- パート1：総合的な洞察サマリー ---
     summary_div = html.Div([
-        html.H4("総合的な洞察サマリー"),
-        html.Blockquote(blueprint_data["summary"])
+        html.H4("総合的な洞察サマリー", style={'marginBottom': '15px'}),
+        dcc.Markdown(blueprint_data["summary"], style={
+            'backgroundColor': '#e9f2fa',
+            'padding': '15px',
+            'borderRadius': '8px',
+            'border': '1px solid #cce5ff'
+        })
     ])
 
-    # --- パート2：発見された「法則」の全リスト ---
+    # --- パート2：意外な発見のハイライト ---
+    hidden_gems_div = html.Div([])
+    if blueprint_data.get("hidden_gems"):
+        gems_content = []
+        for gem in blueprint_data["hidden_gems"]:
+            gems_content.append(html.Div([
+                html.H6(f"💡 {gem['発見']}", style={'marginBottom': '5px'}),
+                html.P(f"意外性: {gem['意外性']}", style={'fontSize': '14px', 'color': '#666'})
+            ], style={
+                'backgroundColor': '#fff3cd',
+                'padding': '10px',
+                'borderRadius': '5px',
+                'marginBottom': '10px',
+                'border': '1px solid #ffeaa7'
+            }))
+
+        hidden_gems_div = html.Div([
+            html.H4("🎯 特に注目すべき発見", style={'marginTop': '30px', 'marginBottom': '15px'}),
+            html.Div(gems_content)
+        ])
+
+    # --- パート3：発見された「法則」の全リスト ---
+    rules_df = blueprint_data['rules_df']
+
+    # カテゴリー別に色分けする
+    category_colors = {
+        "スキル相性": "#e3f2fd",
+        "負荷分散戦略": "#f3e5f5",
+        "個人配慮": "#e8f5e9",
+        "ローテーション戦略": "#fff3e0",
+        "リスク回避": "#ffebee",
+        "時系列戦略": "#f3e5f5"
+    }
+
+    # テーブルのスタイル設定
+    style_data_conditional = []
+    for category, color in category_colors.items():
+        style_data_conditional.append({
+            'if': {'filter_query': '{法則のカテゴリー} = "' + category + '"'},
+            'backgroundColor': color
+        })
+
+    # 詳細データ列をJSON文字列に変換（表示用）
+    if '詳細データ' in rules_df.columns:
+        rules_df['詳細データ'] = rules_df['詳細データ'].apply(
+            lambda x: json.dumps(x, ensure_ascii=False) if isinstance(x, dict) else str(x)
+        )
+
     rules_table_div = html.Div([
-        html.H4(f"発見された全{len(blueprint_data['rules_df'])}個の法則リスト"),
-        html.P("「法則の強度」でソートされています。これがあなたの職場の「暗黙の優先順位」です。"),
+        html.H4(f"発見された全{len(rules_df)}個の法則リスト", style={'marginTop': '30px', 'marginBottom': '15px'}),
+        html.P("「法則の強度」でソートされています。これがあなたの職場の「暗黙の優先順位」です。", style={'marginBottom': '15px'}),
+
+        # カテゴリー別の統計
+        html.Div([
+            html.H5("カテゴリー別の法則数", style={'marginBottom': '10px'}),
+            html.Div([
+                html.Span(f"{cat}: {count}個", style={
+                    'backgroundColor': color,
+                    'padding': '5px 10px',
+                    'borderRadius': '15px',
+                    'marginRight': '10px',
+                    'display': 'inline-block',
+                    'fontSize': '14px'
+                })
+                for cat, count in rules_df['法則のカテゴリー'].value_counts().items()
+                if (color := category_colors.get(cat))
+            ])
+        ], style={'marginBottom': '20px'}),
+
         dash_table.DataTable(
-            data=blueprint_data['rules_df'].to_dict('records'),
-            columns=[{'name': i, 'id': i} for i in blueprint_data['rules_df'].columns],
-            style_cell={'textAlign': 'left'},
-            style_header={'fontWeight': 'bold'},
+            data=rules_df.to_dict('records'),
+            columns=[
+                {'name': '法則のカテゴリー', 'id': '法則のカテゴリー'},
+                {'name': '発見された法則', 'id': '発見された法則'},
+                {'name': '法則の強度', 'id': '法則の強度'},
+                {'name': '詳細データ', 'id': '詳細データ'}
+            ],
+            style_cell={
+                'textAlign': 'left',
+                'whiteSpace': 'normal',
+                'height': 'auto',
+                'minWidth': '80px',
+                'maxWidth': '300px'
+            },
+            style_header={
+                'fontWeight': 'bold',
+                'backgroundColor': '#f0f0f0'
+            },
+            style_data_conditional=style_data_conditional,
             sort_action="native",
-        ) if not blueprint_data['rules_df'].empty else html.P("表示できる法則がありません。")
+            filter_action="native",
+            page_size=20,
+            style_data={
+                'whiteSpace': 'normal',
+                'height': 'auto',
+            }
+        ) if not rules_df.empty else html.P("表示できる法則がありません。")
     ])
 
-    return html.Div([summary_div, html.Hr(), rules_table_div])
+    # --- パート4：実践的なアドバイス ---
+    advice_div = html.Div([
+        html.H4("📝 この分析結果の活用方法", style={'marginTop': '30px', 'marginBottom': '15px'}),
+        html.Div([
+            html.Ul([
+                html.Li("強度0.8以上の法則は\u300c絶対的なルール\u300dとして新人教育に活用"),
+                html.Li("スキル相性の情報は、新規採用時の配置計画に活用"),
+                html.Li("個人配慮パターンは、引き継ぎ時の重要情報として文書化"),
+                html.Li("リスク回避ルールは、品質管理のチェックリストに追加"),
+            ])
+        ], style={
+            'backgroundColor': '#e8f5e9',
+            'padding': '15px',
+            'borderRadius': '8px',
+            'border': '1px solid #c8e6c9'
+        })
+    ])
+
+    return html.Div([
+        summary_div,
+        hidden_gems_div,
+        html.Hr(),
+        rules_table_div,
+        html.Hr(),
+        advice_div
+    ])
 
 
 @app.callback(

--- a/shift_suite/tasks/blueprint_analyzer.py
+++ b/shift_suite/tasks/blueprint_analyzer.py
@@ -1,120 +1,513 @@
 from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from itertools import combinations
+
+import numpy as np
 import pandas as pd
 
+log = logging.getLogger(__name__)
 
-def _calculate_role_first_rules(long_df: pd.DataFrame) -> list:
-    """役割軸の法則を抽出する"""
+
+def _analyze_skill_synergy(long_df: pd.DataFrame) -> list:
+    """スキル相性マトリクス分析：誰と誰を組ませると上手くいくか"""
     rules = []
-    if 'role' not in long_df.columns:
+
+    if 'staff' not in long_df.columns:
         return rules
 
-    for role, group_df in long_df.groupby('role'):
-        total_days = group_df['ds'].dt.date.nunique()
-        unique_staff = group_df['staff'].nunique()
-        if total_days > 0 and unique_staff > 0:
-            # 「固定度スコア」を計算
-            stability_score = 1 - (unique_staff / total_days)
-            rules.append({
-                "法則のカテゴリー": "役割軸",
-                "発見された法則": f"「{role}」は、少数の固定メンバーで担当されている",
-                "法則の強度": round(stability_score, 2)
-            })
+    # 同時勤務の実績を集計
+    daily_staff = long_df[long_df['parsed_slots_count'] > 0].groupby(
+        ['ds', 'code']
+    )['staff'].apply(list).reset_index()
+
+    # ペアごとの共働回数をカウント
+    pair_counts = defaultdict(int)
+    total_shifts_per_staff = long_df.groupby('staff')['ds'].nunique()
+
+    for _, row in daily_staff.iterrows():
+        staff_list = row['staff']
+        if len(staff_list) >= 2:
+            for pair in combinations(sorted(set(staff_list)), 2):
+                pair_counts[pair] += 1
+
+    # 期待値との乖離を計算
+    for (staff1, staff2), actual_count in pair_counts.items():
+        if staff1 not in total_shifts_per_staff.index or staff2 not in total_shifts_per_staff.index:
+            continue
+
+        # 独立した場合の期待共働回数
+        total_days = long_df['ds'].dt.date.nunique()
+        prob1 = total_shifts_per_staff[staff1] / total_days
+        prob2 = total_shifts_per_staff[staff2] / total_days
+        expected_count = prob1 * prob2 * total_days
+
+        if expected_count > 0:
+            synergy_score = actual_count / expected_count
+
+            # 期待値から大きく乖離している組み合わせを検出
+            if synergy_score > 1.5:  # 期待値の1.5倍以上
+                rules.append({
+                    "法則のカテゴリー": "スキル相性",
+                    "発見された法則": f"「{staff1}」と「{staff2}」は意図的に同じシフトに配置される（相性◎）",
+                    "法則の強度": round(min(synergy_score / 2, 1.0), 2),
+                    "詳細データ": {"実績": actual_count, "期待値": round(expected_count, 1)}
+                })
+            elif synergy_score < 0.3:  # 期待値の30%未満
+                rules.append({
+                    "法則のカテゴリー": "スキル相性",
+                    "発見された法則": f"「{staff1}」と「{staff2}」は意図的に別シフトに配置される（相性×）",
+                    "法則の強度": round(1.0 - synergy_score, 2),
+                    "詳細データ": {"実績": actual_count, "期待値": round(expected_count, 1)}
+                })
+
     return rules
 
 
-def _calculate_person_first_rules(long_df: pd.DataFrame) -> list:
-    """個人軸の法則を抽出する"""
+def _analyze_workload_distribution(long_df: pd.DataFrame) -> list:
+    """負荷バランシング戦略：繁忙時間帯での人員配置パターン"""
     rules = []
-    if long_df.empty:
+
+    if not {'staff', 'role'}.issubset(long_df.columns):
         return rules
 
-    daily_work = long_df.drop_duplicates(subset=['ds', 'staff'])
+    # 時間帯別の平均人員数を計算
+    time_staff_counts = long_df[long_df['parsed_slots_count'] > 0].groupby(
+        long_df['ds'].dt.time
+    )['staff'].nunique().reset_index()
+    time_staff_counts.columns = ['time', 'avg_staff']
 
-    for staff, group_df in daily_work.groupby('staff'):
-        if len(group_df) < 2:
-            stability_score = 1.0  # 勤務が1日だけならパターンは固定的とみなす
-        else:
-            weekday_std = group_df['ds'].dt.dayofweek.std()
-            stability_score = 1 / (1 + weekday_std) if not pd.isna(weekday_std) else 0
+    # 繁忙時間帯を特定（上位25%）
+    threshold = time_staff_counts['avg_staff'].quantile(0.75)
+    busy_times = time_staff_counts[time_staff_counts['avg_staff'] >= threshold]['time'].tolist()
 
+    if not busy_times:
+        return rules
+
+    # 繁忙時間帯での職員の経験値分布を分析
+    busy_df = long_df[long_df['ds'].dt.time.isin(busy_times)]
+
+    # 各職員の総勤務日数（経験値の代理指標）
+    staff_experience = long_df.groupby('staff')['ds'].nunique().sort_values(ascending=False)
+    median_exp = staff_experience.median()
+
+    # 繁忙時間帯でのベテラン配置率
+    busy_staff = busy_df['staff'].unique()
+    veteran_staff = staff_experience[staff_experience > median_exp].index
+    veteran_ratio = len(set(busy_staff) & set(veteran_staff)) / len(busy_staff) if len(busy_staff) > 0 else 0
+
+    if veteran_ratio > 0.7:
         rules.append({
-            "法則のカテゴリー": "個人軸",
-            "発見された法則": f"「{staff}」さんは、毎週ほぼ同じ曜日に勤務している",
-            "法則の強度": round(stability_score, 2)
+            "法則のカテゴリー": "負荷分散戦略",
+            "発見された法則": "繁忙時間帯には必ずベテラン職員を優先配置している",
+            "法則の強度": round(veteran_ratio, 2),
+            "詳細データ": {"繁忙時間帯": [str(t) for t in busy_times[:5]], "ベテラン配置率": f"{veteran_ratio:.1%}"}
         })
+
+    # 役割別の分布も分析
+    for role in busy_df['role'].unique():
+        role_ratio = len(busy_df[busy_df['role'] == role]) / len(busy_df)
+        if role_ratio > 0.4:
+            rules.append({
+                "法則のカテゴリー": "負荷分散戦略",
+                "発見された法則": f"繁忙時間帯では「{role}」の配置を重視している",
+                "法則の強度": round(role_ratio, 2),
+                "詳細データ": {"役割比率": f"{role_ratio:.1%}"}
+            })
+
     return rules
 
 
-def _calculate_sequential_rules(long_df: pd.DataFrame) -> list:
-    """順序の法則を抽出する"""
+def _analyze_personal_consideration(long_df: pd.DataFrame) -> list:
+    """個人事情配慮パターン：特定職員への定期的な配慮"""
     rules = []
-    if 'is_night' not in long_df.columns or not long_df['is_night'].any():
+
+    if 'staff' not in long_df.columns:
         return rules
 
-    night_shifts = long_df[long_df['is_night']].sort_values('ds')
-    if night_shifts.empty:
-        return rules
+    # 各職員の勤務パターンを分析
+    for staff in long_df['staff'].unique():
+        staff_df = long_df[long_df['staff'] == staff]
 
-    total_night_shifts = len(night_shifts)
-    off_after_night = 0
+        # 曜日×時間帯の勤務頻度を計算
+        staff_df['dow'] = staff_df['ds'].dt.dayofweek
+        staff_df['hour'] = staff_df['ds'].dt.hour
 
-    for index, row in night_shifts.iterrows():
-        next_day = row['ds'].date() + pd.Timedelta(days=1)
-        next_day_shifts = long_df[
-            (long_df['staff'] == row['staff']) &
-            (long_df['ds'].dt.date == next_day)
-        ]
-        if next_day_shifts.empty or next_day_shifts['parsed_slots_count'].sum() == 0:
-            off_after_night += 1
+        # 特定の曜日・時間帯を避けているパターンを検出
+        dow_hour_counts = staff_df.groupby(['dow', 'hour']).size()
+        total_weeks = staff_df['ds'].dt.isocalendar().week.nunique()
 
-    off_after_night_ratio = off_after_night / total_night_shifts if total_night_shifts > 0 else 0
+        # 期待頻度と実際の頻度を比較
+        for (dow, hour), count in dow_hour_counts.items():
+            expected_count = total_weeks * 0.8  # 80%の出現を期待値とする
 
-    rules.append({
-        "法則のカテゴリー": "順序の法則",
-        "発見された法則": "「夜勤」の翌日は「休み」が割り当てられる傾向がある",
-        "法則の強度": round(off_after_night_ratio, 2)
-    })
+            if count < expected_count * 0.2:  # 期待値の20%未満
+                dow_names = ['月', '火', '水', '木', '金', '土', '日']
+                rules.append({
+                    "法則のカテゴリー": "個人配慮",
+                    "発見された法則": f"「{staff}」は{dow_names[dow]}曜日の{hour}時台をほぼ避けている（個人事情？）",
+                    "法則の強度": round(1.0 - (count / expected_count if expected_count > 0 else 0), 2),
+                    "詳細データ": {"出現回数": count, "期待回数": round(expected_count, 1)}
+                })
+
+        # 月初・月末パターンも分析
+        staff_df['day'] = staff_df['ds'].dt.day
+        month_pattern = staff_df.groupby(staff_df['day'] <= 5)['ds'].count()
+
+        if len(month_pattern) == 2:
+            early_month_ratio = month_pattern[True] / month_pattern.sum()
+            if early_month_ratio < 0.1:
+                rules.append({
+                    "法則のカテゴリー": "個人配慮",
+                    "発見された法則": f"「{staff}」は月初（1-5日）の勤務をほぼ避けている",
+                    "法則の強度": round(1.0 - early_month_ratio, 2),
+                    "詳細データ": {"月初勤務率": f"{early_month_ratio:.1%}"}
+                })
+
     return rules
 
+
+def _analyze_rotation_strategy(long_df: pd.DataFrame) -> list:
+    """ローテーション戦略：公平性を保つための複雑なルール"""
+    rules = []
+
+    if not {'staff', 'code'}.issubset(long_df.columns):
+        return rules
+
+    # 各職員の勤務パターンの連続性を分析
+    for staff in long_df['staff'].unique():
+        staff_df = long_df[long_df['staff'] == staff].sort_values('ds')
+
+        # 連続勤務日数の計算
+        staff_dates = staff_df[staff_df['parsed_slots_count'] > 0]['ds'].dt.date.unique()
+
+        if len(staff_dates) < 2:
+            continue
+
+        # 連続勤務のカウント
+        consecutive_counts = []
+        current_streak = 1
+
+        for i in range(1, len(staff_dates)):
+            if (staff_dates[i] - staff_dates[i-1]).days == 1:
+                current_streak += 1
+            else:
+                if current_streak > 1:
+                    consecutive_counts.append(current_streak)
+                current_streak = 1
+
+        if current_streak > 1:
+            consecutive_counts.append(current_streak)
+
+        # 長期連勤の検出
+        if consecutive_counts:
+            max_consecutive = max(consecutive_counts)
+            avg_consecutive = np.mean(consecutive_counts)
+
+            if max_consecutive <= 3 and avg_consecutive < 2.5:
+                rules.append({
+                    "法則のカテゴリー": "ローテーション戦略",
+                    "発見された法則": f"「{staff}」の連続勤務は必ず3日以内に制限されている",
+                    "法則の強度": round(1.0 - (max_consecutive - 3) / 7, 2),
+                    "詳細データ": {"最大連続": max_consecutive, "平均連続": round(avg_consecutive, 1)}
+                })
+
+        # 勤務コードのローテーションパターン
+        code_sequence = staff_df[staff_df['parsed_slots_count'] > 0]['code'].tolist()
+
+        if len(code_sequence) >= 3:
+            # 同じコードの連続を避けているか
+            same_code_runs = []
+            current_run = 1
+
+            for i in range(1, len(code_sequence)):
+                if code_sequence[i] == code_sequence[i-1]:
+                    current_run += 1
+                else:
+                    if current_run > 1:
+                        same_code_runs.append(current_run)
+                    current_run = 1
+
+            if same_code_runs and max(same_code_runs) <= 2:
+                rules.append({
+                    "法則のカテゴリー": "ローテーション戦略",
+                    "発見された法則": f"「{staff}」は同じ勤務パターンが3日以上続かないようローテーションされている",
+                    "法則の強度": 0.8,
+                    "詳細データ": {"最大連続同一勤務": max(same_code_runs)}
+                })
+
+    return rules
+
+
+def _analyze_risk_mitigation(long_df: pd.DataFrame) -> list:
+    """リスク回避ルール：トラブル防止のための暗黙の配置ルール"""
+    rules = []
+
+    if not {'staff', 'role'}.issubset(long_df.columns):
+        return rules
+
+    # 各時間帯での新人比率を分析
+    staff_experience = long_df.groupby('staff')['ds'].nunique()
+    experience_threshold = staff_experience.quantile(0.25)  # 下位25%を新人とする
+    new_staff = staff_experience[staff_experience <= experience_threshold].index
+
+    # 時間帯別の新人比率
+    time_groups = long_df[long_df['parsed_slots_count'] > 0].groupby(
+        [long_df['ds'].dt.date, long_df['ds'].dt.hour]
+    )
+
+    new_staff_only_count = 0
+    total_time_slots = 0
+
+    for (date, hour), group in time_groups:
+        unique_staff = group['staff'].unique()
+        if len(unique_staff) > 1:  # 複数人勤務の場合のみ
+            total_time_slots += 1
+            if all(s in new_staff for s in unique_staff):
+                new_staff_only_count += 1
+
+    if total_time_slots > 0:
+        new_staff_only_ratio = new_staff_only_count / total_time_slots
+
+        if new_staff_only_ratio < 0.01:  # 1%未満
+            rules.append({
+                "法則のカテゴリー": "リスク回避",
+                "発見された法則": "新人だけのシフトは絶対に作らない（必ずベテランを1人は配置）",
+                "法則の強度": round(1.0 - new_staff_only_ratio, 2),
+                "詳細データ": {"新人のみシフト発生率": f"{new_staff_only_ratio:.1%}"}
+            })
+
+    # 特定の役割の組み合わせ分析
+    role_combinations = defaultdict(int)
+
+    for (date, time), group in long_df.groupby([long_df['ds'].dt.date, long_df['ds'].dt.time]):
+        roles = group['role'].unique()
+        if len(roles) >= 2:
+            for combo in combinations(sorted(roles), 2):
+                role_combinations[combo] += 1
+
+    # 期待値と比較して異常に少ない組み合わせを検出
+    if role_combinations:
+        avg_count = np.mean(list(role_combinations.values()))
+        for combo, count in role_combinations.items():
+            if count < avg_count * 0.1:  # 平均の10%未満
+                rules.append({
+                    "法則のカテゴリー": "リスク回避",
+                    "発見された法則": f"「{combo[0]}」と「{combo[1]}」は同時配置を避けている（業務上の理由？）",
+                    "法則の強度": round(1.0 - (count / avg_count if avg_count > 0 else 0), 2),
+                    "詳細データ": {"出現回数": count, "平均": round(avg_count, 1)}
+                })
+
+    return rules
+
+
+def _analyze_temporal_context(long_df: pd.DataFrame) -> list:
+    """時系列コンテキスト分析：時期による配置戦略の変化"""
+    rules = []
+
+    if 'ds' not in long_df.columns:
+        return rules
+
+    # 月別の傾向分析
+    long_df['month'] = long_df['ds'].dt.month
+    long_df['day'] = long_df['ds'].dt.day
+
+    # 月初・月中・月末での人員配置の違い
+    long_df['period'] = pd.cut(long_df['day'], bins=[0, 10, 20, 31], labels=['月初', '月中', '月末'])
+
+    period_stats = long_df[long_df['parsed_slots_count'] > 0].groupby(['period']).agg({
+        'staff': 'nunique',
+        'ds': 'count'
+    })
+
+    if len(period_stats) > 1:
+        period_stats['avg_staff_per_slot'] = period_stats['ds'] / period_stats['staff']
+
+        # 月末が特に手厚い配置になっているか
+        if 'month_end_ratio' in locals():
+            month_end_ratio = period_stats.loc['月末', 'avg_staff_per_slot'] / period_stats['avg_staff_per_slot'].mean()
+            if month_end_ratio > 1.2:
+                rules.append({
+                    "法則のカテゴリー": "時系列戦略",
+                    "発見された法則": "月末は通常より手厚い人員配置を行っている（締め作業対応？）",
+                    "法則の強度": round(min(month_end_ratio - 1.0, 1.0), 2),
+                    "詳細データ": {"月末配置倍率": f"{month_end_ratio:.2f}倍"}
+                })
+
+    # 曜日による戦略の違い
+    long_df['dow'] = long_df['ds'].dt.dayofweek
+    dow_names = ['月', '火', '水', '木', '金', '土', '日']
+
+    dow_stats = long_df[long_df['parsed_slots_count'] > 0].groupby('dow').agg({
+        'staff': 'nunique',
+        'code': lambda x: x.value_counts().to_dict()
+    })
+
+    # 週末の特別な配置パターン
+    if 5 in dow_stats.index and 6 in dow_stats.index:  # 土日
+        weekend_staff = dow_stats.loc[[5, 6], 'staff'].mean()
+        weekday_staff = dow_stats.loc[[0, 1, 2, 3, 4], 'staff'].mean() if len(dow_stats) > 2 else 0
+
+        if weekday_staff > 0:
+            weekend_ratio = weekend_staff / weekday_staff
+            if weekend_ratio < 0.7:
+                rules.append({
+                    "法則のカテゴリー": "時系列戦略",
+                    "発見された法則": "週末は平日の70%以下の省力体制で運営している",
+                    "法則の強度": round(1.0 - weekend_ratio, 2),
+                    "詳細データ": {"週末/平日比": f"{weekend_ratio:.1%}"}
+                })
+
+    return rules
+
+
+def _extract_surprising_insights(rules_df: pd.DataFrame) -> list:
+    """意外性の高い発見をピックアップ"""
+    if rules_df.empty:
+        return []
+
+    surprising = []
+
+    # 個人配慮カテゴリーから意外なものを抽出
+    personal_rules = rules_df[rules_df['法則のカテゴリー'] == '個人配慮']
+    if not personal_rules.empty:
+        top_personal = personal_rules.nlargest(3, '法則の強度')
+        for _, rule in top_personal.iterrows():
+            surprising.append({
+                "発見": rule['発見された法則'],
+                "意外性": "特定個人への配慮が明確にデータに現れている"
+            })
+
+    # スキル相性で相性が悪いペア
+    bad_synergy = rules_df[
+        (rules_df['法則のカテゴリー'] == 'スキル相性') &
+        (rules_df['発見された法則'].str.contains('別シフト'))
+    ]
+    if not bad_synergy.empty:
+        for _, rule in bad_synergy.iterrows():
+            surprising.append({
+                "発見": rule['発見された法則'],
+                "意外性": "意図的に組み合わせを避けている職員ペアの存在"
+            })
+
+    return surprising
+
+
+def _generate_deep_insights_summary(rules_df: pd.DataFrame) -> str:
+    """より洞察的なサマリーを生成"""
+    if rules_df.empty:
+        return "分析可能な法則が見つかりませんでした。"
+
+    summary_parts = []
+
+    # カテゴリー別の法則数をカウント
+    category_counts = rules_df['法則のカテゴリー'].value_counts()
+
+    summary_parts.append("## 🔍 シフト作成の深層分析結果\n")
+    summary_parts.append(f"合計 **{len(rules_df)}個** の暗黙のルールを発見しました。\n")
+
+    # 最も強い法則トップ3
+    top_rules = rules_df.nlargest(3, '法則の強度')
+    summary_parts.append("\n### 📊 最も影響力の強いルール TOP3\n")
+    for i, (_, rule) in enumerate(top_rules.iterrows(), 1):
+        summary_parts.append(f"{i}. **{rule['発見された法則']}** (強度: {rule['法則の強度']})")
+
+    # カテゴリー別の特徴
+    summary_parts.append("\n### 🎯 カテゴリー別の特徴\n")
+
+    if 'スキル相性' in category_counts:
+        summary_parts.append(f"- **人間関係への配慮**: {category_counts['スキル相性']}個のルール")
+    if '個人配慮' in category_counts:
+        summary_parts.append(f"- **個人事情への対応**: {category_counts['個人配慮']}個のルール")
+    if 'リスク回避' in category_counts:
+        summary_parts.append(f"- **トラブル防止策**: {category_counts['リスク回避']}個のルール")
+
+    # 総括
+    summary_parts.append("\n### 💡 総括")
+    summary_parts.append("このシフトは、表面的なルールだけでなく、")
+    summary_parts.append("職員間の相性、個人の事情、リスク管理など、")
+    summary_parts.append("**多次元的な配慮**が複雑に組み合わさって作成されています。")
+
+    return "\n".join(summary_parts)
 
 
 def create_blueprint_list(long_df: pd.DataFrame) -> dict:
-    """シフトデータから法則を網羅的に抽出し、強度順のリストとして返す。"""
+    """シフトデータから深層的な法則を抽出し、作成者の暗黙知を可視化する"""
     if long_df.empty:
         return {"error": "分析対象の勤務データがありません。"}
 
-    # --- データ準備 ---
-    long_df['date'] = pd.to_datetime(long_df['ds'].dt.date)
+    log.info("ブループリント分析を開始します...")
+
+    # データ準備
+    long_df = long_df.copy()
+    long_df['date'] = pd.to_datetime(long_df['ds']).dt.date
     long_df['is_night'] = long_df['code'].astype(str).str.contains("夜", na=False)
 
-    # --- 全カテゴリーの法則を無条件に抽出 ---
-    role_rules = _calculate_role_first_rules(long_df)
-    person_rules = _calculate_person_first_rules(long_df)
-    sequential_rules = _calculate_sequential_rules(long_df)
+    # 全カテゴリーの法則を抽出
+    all_rules = []
 
-    all_rules = role_rules + person_rules + sequential_rules
+    try:
+        # 1. スキル相性分析
+        log.info("スキル相性分析を実行中...")
+        synergy_rules = _analyze_skill_synergy(long_df)
+        all_rules.extend(synergy_rules)
+        log.info(f"スキル相性: {len(synergy_rules)}個のルールを発見")
+
+        # 2. 負荷分散戦略
+        log.info("負荷分散戦略分析を実行中...")
+        workload_rules = _analyze_workload_distribution(long_df)
+        all_rules.extend(workload_rules)
+        log.info(f"負荷分散: {len(workload_rules)}個のルールを発見")
+
+        # 3. 個人配慮パターン
+        log.info("個人配慮パターン分析を実行中...")
+        personal_rules = _analyze_personal_consideration(long_df)
+        all_rules.extend(personal_rules)
+        log.info(f"個人配慮: {len(personal_rules)}個のルールを発見")
+
+        # 4. ローテーション戦略
+        log.info("ローテーション戦略分析を実行中...")
+        rotation_rules = _analyze_rotation_strategy(long_df)
+        all_rules.extend(rotation_rules)
+        log.info(f"ローテーション: {len(rotation_rules)}個のルールを発見")
+
+        # 5. リスク回避ルール
+        log.info("リスク回避ルール分析を実行中...")
+        risk_rules = _analyze_risk_mitigation(long_df)
+        all_rules.extend(risk_rules)
+        log.info(f"リスク回避: {len(risk_rules)}個のルールを発見")
+
+        # 6. 時系列パターン
+        log.info("時系列パターン分析を実行中...")
+        temporal_rules = _analyze_temporal_context(long_df)
+        all_rules.extend(temporal_rules)
+        log.info(f"時系列: {len(temporal_rules)}個のルールを発見")
+
+    except Exception as e:
+        log.error(f"分析中にエラーが発生しました: {e}", exc_info=True)
+        return {"error": f"分析中にエラーが発生しました: {str(e)}"}
 
     if not all_rules:
         return {
-            "summary": "分析可能な法則が見つかりませんでした。",
-            "rules_df": pd.DataFrame()
+            "summary": "分析可能な法則が見つかりませんでした。データ量が不足している可能性があります。",
+            "rules_df": pd.DataFrame(),
+            "hidden_gems": []
         }
 
-    # --- 法則を強度順にソート ---
+    # 法則を強度順にソート
     rules_df = pd.DataFrame(all_rules).sort_values("法則の強度", ascending=False).reset_index(drop=True)
 
-    # --- 総合的な洞察サマリーを生成 ---
-    summary_text = "このシフトの作成プロセスは、複数の法則が組み合わさってできています。\n"
-    if not rules_df.empty:
-        top_rule = rules_df.iloc[0]
-        summary_text += f"最も強い影響力を持つのは、**『{top_rule['法則のカテゴリー']}』**の法則、具体的には**「{top_rule['発見された法則']}」**（強度: {top_rule['法則の強度']}）です。"
-        if len(rules_df) > 1:
-            second_rule = rules_df.iloc[1]
-            summary_text += f"\n次いで、**『{second_rule['法則のカテゴリー']}』**の**「{second_rule['発見された法則']}」**（強度: {second_rule['法則の強度']}）も重要なルールとなっています。"
+    # 総合的な洞察サマリーを生成
+    summary_text = _generate_deep_insights_summary(rules_df)
 
-    summary_text += "\n\n以下のリスト全体を眺めることで、あなたの職場のシフト作成における『暗黙の優先順位』をより深く理解できます。"
+    # 意外な発見を抽出
+    hidden_gems = _extract_surprising_insights(rules_df)
+
+    log.info(f"分析完了: 合計{len(rules_df)}個のルールを発見")
 
     return {
         "summary": summary_text,
-        "rules_df": rules_df
+        "rules_df": rules_df,
+        "hidden_gems": hidden_gems
     }


### PR DESCRIPTION
## Summary
- enhance blueprint_analysis to infer complex scheduling rules like skill synergy, workload and risk strategies
- overhaul blueprint tab UI to highlight insights and advice

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685e92c2b94083338770dbcfd3d3336b