### PR TITLE
Fix blueprint analyzer and UI

### DIFF
--- a/dash_app.py
+++ b/dash_app.py
@@ -2156,7 +2156,7 @@ def update_blueprint_analysis_content(n_clicks):
         "個人配慮": "#e8f5e9",
         "ローテーション戦略": "#fff3e0",
         "リスク回避": "#ffebee",
-        "時系列戦略": "#f3e5f5"
+        "時系列戦略": "#e0f2f1"
     }
 
     # テーブルのスタイル設定


### PR DESCRIPTION
## Summary
- prevent `UnboundLocalError` in blueprint analysis
- avoid `SettingWithCopyWarning` by copying staff slice
- add constants for analyzer thresholds
- differentiate colours for categories in Dash app

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas et al.)*

------
https://chatgpt.com/codex/tasks/task_e_685e975f49448333b9731d73ca28c922