### PR TITLE
Add integrated logic analysis dashboard

### DIFF
--- a/shift_suite/tasks/integrated_creation_logic_viewer.py
+++ b/shift_suite/tasks/integrated_creation_logic_viewer.py
@@ -1,0 +1,63 @@
+"""
+シフト作成ロジックの完全解明結果を統合表示するビューア
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+import pandas as pd
+from dash import dcc, html
+
+from .shift_creation_logic_analyzer import ShiftCreationLogicAnalyzer
+from .shift_creation_forensics import ShiftCreationForensics
+from .shift_mind_reader import ShiftMindReader
+
+
+def create_creation_logic_analysis_tab() -> html.Div:
+    """Return layout for the creation logic analysis tab."""
+    return html.Div([
+        html.H3("シフト作成ロジック完全解明", style={"marginBottom": "20px"}),
+        dcc.RadioItems(
+            id="logic-analysis-depth",
+            options=[
+                {"label": "概要", "value": "basic"},
+                {"label": "詳細", "value": "detailed"},
+                {"label": "完全", "value": "complete"},
+                {"label": "究極", "value": "ultimate"},
+            ],
+            value="basic",
+            inline=True,
+            style={"marginBottom": "10px"},
+        ),
+        html.Button(
+            "シフト作成ロジックを解明",
+            id="analyze-creation-logic-button",
+            n_clicks=0,
+            style={"marginLeft": "10px"},
+        ),
+        html.Div(id="logic-analysis-progress", style={"marginTop": "10px"}),
+        dcc.Loading(
+            id="logic-analysis-loading",
+            type="default",
+            children=html.Div(id="creation-logic-results"),
+        ),
+    ])
+
+
+def run_integrated_logic_analysis(long_df: pd.DataFrame, depth: str) -> html.Div:
+    """Execute all analyzers and return a summary view."""
+    logic_analyzer = ShiftCreationLogicAnalyzer()
+    forensics = ShiftCreationForensics()
+    mind_reader = ShiftMindReader()
+
+    results: Dict[str, Any] = {}
+
+    if depth in ["basic", "detailed", "complete", "ultimate"]:
+        results["logic_results"] = logic_analyzer.reverse_engineer_creation_process(long_df)
+    if depth in ["detailed", "complete", "ultimate"]:
+        results["forensics_results"] = forensics.full_forensic_analysis(long_df)
+    if depth in ["complete", "ultimate"]:
+        results["mind_results"] = mind_reader.read_creator_mind(long_df)
+
+    return html.Pre(json.dumps(results, indent=2, ensure_ascii=False))

--- a/shift_suite/tasks/shift_creation_forensics.py
+++ b/shift_suite/tasks/shift_creation_forensics.py
@@ -1,0 +1,21 @@
+"""
+シフト作成過程をフォレンジック解析するエンジン
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+
+class ShiftCreationForensics:
+    """Forensic investigation of schedule creation."""
+
+    def full_forensic_analysis(self, long_df: pd.DataFrame) -> Dict[str, Any]:
+        """Perform forensic analysis and return results."""
+        log.info("シフト作成フォレンジック解析中...")
+        # 実際の解析ロジックは未実装
+        return {}

--- a/shift_suite/tasks/shift_creation_logic_analyzer.py
+++ b/shift_suite/tasks/shift_creation_logic_analyzer.py
@@ -1,0 +1,21 @@
+"""
+シフト作成ロジックを逆解析するエンジン
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+
+class ShiftCreationLogicAnalyzer:
+    """Analyze rules used to create schedules."""
+
+    def reverse_engineer_creation_process(self, long_df: pd.DataFrame) -> Dict[str, Any]:
+        """Return dictionary summarising inferred logic."""
+        log.info("シフト作成ロジックを解析中...")
+        # 実際の解析ロジックは未実装
+        return {}


### PR DESCRIPTION
## Summary
- integrate new tab for schedule creation logic analysis
- implement skeleton analyzers and viewer modules
- store analysis results and display in Dash app

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_e_685fbaa68814833381b4dc1ec4805f97