### PR TITLE
Fix import path for analyzers

### DIFF
--- a/shift_suite/tasks/shift_mind_reader.py
+++ b/shift_suite/tasks/shift_mind_reader.py
@@ -12,7 +12,7 @@ import pandas as pd
 import lightgbm as lgb
 from sklearn.tree import DecisionTreeClassifier
 
-from ..analyzers import (
+from .analyzers import (
     RestTimeAnalyzer,
     WorkPatternAnalyzer,
     AttendanceBehaviorAnalyzer,


### PR DESCRIPTION
## Summary
- fix relative import for analyzers in `ShiftMindReader`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686145b139708333b86eb13abf28a232