### PR TITLE
Fix module import path

### DIFF
--- a/shift_suite/tasks/shift_mind_reader.py
+++ b/shift_suite/tasks/shift_mind_reader.py
@@ -17,7 +17,7 @@ from .analyzers import (
     WorkPatternAnalyzer,
     AttendanceBehaviorAnalyzer,
 )
-from ..fatigue import _features as calc_fatigue_features
+from .fatigue import _features as calc_fatigue_features
 from ..fairness import calculate_jain_index
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- correct the relative import in `shift_mind_reader.py`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686147a6513c83338697cd511f3d39c4