### PR TITLE
Fix fairness module import

### DIFF
--- a/shift_suite/tasks/shift_mind_reader.py
+++ b/shift_suite/tasks/shift_mind_reader.py
@@ -18,7 +18,7 @@ from .analyzers import (
     AttendanceBehaviorAnalyzer,
 )
 from .fatigue import _features as calc_fatigue_features
-from ..fairness import calculate_jain_index
+from .fairness import calculate_jain_index
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- correct import path of `calculate_jain_index` in `shift_mind_reader`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68614d54ab6883339ade681b277a0adf