### PR TITLE
Fix join for fatigue features

### DIFF
--- a/shift_suite/tasks/shift_mind_reader.py
+++ b/shift_suite/tasks/shift_mind_reader.py
@@ -128,7 +128,7 @@ class ShiftMindReader:
 
         if not fatigue_features.empty:
             staff_features = staff_features.join(
-                fatigue_features.set_index("staff"), how="left"
+                fatigue_features, how="left"
             )
 
         # additional analyzers


### PR DESCRIPTION
## Summary
- fix call to `join` for fatigue features in `shift_mind_reader`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas et al.)*

------
https://chatgpt.com/codex/tasks/task_e_6861535ce58483339ec848248c6be19e