### PR TITLE
Add debug prints to feature importance

### DIFF
--- a/shift_suite/tasks/quick_logic_analysis.py
+++ b/shift_suite/tasks/quick_logic_analysis.py
@@ -143,6 +143,9 @@ def run_ultra_light_analysis(df: pd.DataFrame) -> dict:
             pd.DataFrame({"feature": features.columns, "importance": model.feature_importances_})
             .nlargest(5, "importance")
         )
+        print("---------- DEBUG: Feature Importances ----------")
+        print(importance)
+        print("------------------------------------------")
         results["feature_importance"] = importance.to_dict("records")
         results["simple_tree"] = model
 


### PR DESCRIPTION
## Summary
- output feature importances in `run_ultra_light_analysis` for debugging

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68622cb2a1fc8333a68691c1f3a009f7