### PR TITLE
Add schedule reconstruction utilities

### DIFF
--- a/shift_suite/tasks/__init__.py
+++ b/shift_suite/tasks/__init__.py
@@ -13,6 +13,9 @@ __all__ = [
     "create_optimal_hire_plan",
     "AdvancedBlueprintEngineV2",
     "ShiftMindReader",
+    "ShiftCreationProcessReconstructor",
+    "ImplicitRuleDiscoverer",
+    "AdvancedImplicitKnowledgeEngine",
 ]
 
 _module_map = {
@@ -28,6 +31,9 @@ _module_map = {
     "daily_cost": "shift_suite.tasks.daily_cost",
     "AdvancedBlueprintEngineV2": "shift_suite.tasks.advanced_blueprint_engine_v2",
     "ShiftMindReader": "shift_suite.tasks.shift_mind_reader",
+    "ShiftCreationProcessReconstructor": "shift_suite.tasks.shift_creation_process_reconstructor",
+    "ImplicitRuleDiscoverer": "shift_suite.tasks.shift_creation_process_reconstructor",
+    "AdvancedImplicitKnowledgeEngine": "shift_suite.tasks.advanced_implicit_knowledge_engine",
 }
 
 

--- a/shift_suite/tasks/advanced_implicit_knowledge_engine.py
+++ b/shift_suite/tasks/advanced_implicit_knowledge_engine.py
@@ -1,0 +1,111 @@
+"""Discover deeper implicit knowledge from schedule data."""
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+import networkx as nx
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ImplicitKnowledge:
+    """Representation of discovered implicit knowledge."""
+
+    category: str
+    description: str
+    strength: float
+    evidence: Dict[str, Any]
+    actionable_advice: str
+    complexity: int
+
+
+class AdvancedImplicitKnowledgeEngine:
+    """Engine combining several analyses."""
+
+    def __init__(self) -> None:
+        self.discovered_knowledge: List[ImplicitKnowledge] = []
+
+    def discover_all_implicit_knowledge(self, long_df: pd.DataFrame) -> Dict[str, Any]:
+        if long_df.empty:
+            return {"discovered_knowledge": [], "knowledge_count": 0}
+
+        knowledge = []
+        knowledge.extend(self._discover_temporal_patterns(long_df))
+        knowledge.extend(self._discover_social_dynamics(long_df))
+
+        knowledge.sort(key=lambda k: k.strength * k.complexity, reverse=True)
+        self.discovered_knowledge = knowledge
+        return {
+            "discovered_knowledge": [self._to_dict(k) for k in knowledge],
+            "knowledge_count": len(knowledge),
+            "summary": self._generate_summary(knowledge),
+        }
+
+    # --- internal -------------------------------------------------------
+    def _discover_temporal_patterns(self, long_df: pd.DataFrame) -> List[ImplicitKnowledge]:
+        df = long_df.copy()
+        df["hour"] = df["ds"].dt.hour
+        counts = df.groupby("hour")["staff"].nunique()
+        if counts.empty:
+            return []
+        low_hours = counts[counts < counts.mean()].index.tolist()
+        if not low_hours:
+            return []
+        return [
+            ImplicitKnowledge(
+                category="temporal",
+                description=f"hours {low_hours} have fewer staff",
+                strength=0.7,
+                evidence={"hours": low_hours},
+                actionable_advice="Use these hours for training",
+                complexity=2,
+            )
+        ]
+
+    def _discover_social_dynamics(self, long_df: pd.DataFrame) -> List[ImplicitKnowledge]:
+        G = nx.Graph()
+        for _, group in long_df.groupby("ds"):
+            staff = group["staff"].unique()
+            for i in range(len(staff)):
+                for j in range(i + 1, len(staff)):
+                    s1, s2 = staff[i], staff[j]
+                    if G.has_edge(s1, s2):
+                        G[s1][s2]["weight"] += 1
+                    else:
+                        G.add_edge(s1, s2, weight=1)
+        if len(G) < 3:
+            return []
+        centrality = nx.betweenness_centrality(G)
+        top = max(centrality, key=centrality.get)
+        return [
+            ImplicitKnowledge(
+                category="social",
+                description=f"{top} plays key role",
+                strength=min(centrality[top] * 5, 1.0),
+                evidence={"centrality": centrality[top]},
+                actionable_advice="Consider backup for key staff",
+                complexity=3,
+            )
+        ]
+
+    def _generate_summary(self, knowledge: List[ImplicitKnowledge]) -> str:
+        if not knowledge:
+            return "No implicit knowledge discovered."
+        counts = Counter(k.category for k in knowledge)
+        lines = [f"- {k}: {v}" for k, v in counts.items()]
+        return "\n".join(lines)
+
+    def _to_dict(self, k: ImplicitKnowledge) -> Dict[str, Any]:
+        return {
+            "category": k.category,
+            "description": k.description,
+            "strength": k.strength,
+            "evidence": k.evidence,
+            "actionable_advice": k.actionable_advice,
+            "complexity": k.complexity,
+        }

--- a/shift_suite/tasks/enhanced_blueprint_callbacks.py
+++ b/shift_suite/tasks/enhanced_blueprint_callbacks.py
@@ -1,0 +1,46 @@
+"""Dash callbacks for enhanced blueprint analysis tab."""
+from __future__ import annotations
+
+
+import plotly.graph_objects as go
+from dash import Input, Output, State, dcc, html
+import pandas as pd
+
+
+def create_enhanced_blueprint_tab() -> html.Div:
+    """Return the layout for the enhanced blueprint tab."""
+    return html.Div(
+        [
+            html.H3("\U0001F9E0 Enhanced Blueprint Analysis"),
+            html.Button("Run", id="enhanced-blueprint-analyze-button", n_clicks=0),
+            html.Div(id="enhanced-blueprint-results"),
+        ]
+    )
+
+
+def register_enhanced_callbacks(app):
+    """Register callbacks for enhanced blueprint analysis."""
+
+    @app.callback(
+        Output("enhanced-blueprint-results", "children"),
+        Input("enhanced-blueprint-analyze-button", "n_clicks"),
+        State("data-loaded", "data"),
+        prevent_initial_call=True,
+    )
+    def _run_analysis(n_clicks, _status):
+        long_df = app.server.config.get("long_df", pd.DataFrame())
+        if long_df.empty:
+            return html.Div("No data loaded")
+        from .shift_creation_process_reconstructor import ShiftCreationProcessReconstructor
+        recon = ShiftCreationProcessReconstructor()
+        result = recon.reconstruct_creation_process(long_df)
+        return dcc.Markdown(f"**decisions**: {result.get('decision_count', 0)}")
+
+
+def create_progress_bar(progress: float, message: str) -> go.Figure:
+    """Utility to show progress."""
+    fig = go.Figure(
+        go.Bar(x=[progress], y=["progress"], orientation="h", text=[f"{progress}%"])
+    )
+    fig.update_layout(xaxis={"range": [0, 100]}, height=40, title=message)
+    return fig

--- a/shift_suite/tasks/shift_creation_process_reconstructor.py
+++ b/shift_suite/tasks/shift_creation_process_reconstructor.py
@@ -1,0 +1,185 @@
+"""Reconstruct shift creation process and infer implicit rules."""
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class CreationState:
+    """State of schedule at a given time."""
+
+    timestamp: pd.Timestamp
+    assigned_slots: Dict[str, List[pd.Timestamp]] = field(default_factory=dict)
+    staff_hours: Dict[str, float] = field(default_factory=dict)
+    consecutive_days: Dict[str, int] = field(default_factory=dict)
+    last_work_date: Dict[str, dt.date] = field(default_factory=dict)
+    role_coverage: Dict[Tuple[pd.Timestamp, str], int] = field(default_factory=dict)
+
+    def copy(self) -> "CreationState":
+        return CreationState(
+            timestamp=self.timestamp,
+            assigned_slots={k: list(v) for k, v in self.assigned_slots.items()},
+            staff_hours=dict(self.staff_hours),
+            consecutive_days=dict(self.consecutive_days),
+            last_work_date=dict(self.last_work_date),
+            role_coverage=dict(self.role_coverage),
+        )
+
+
+@dataclass
+class DecisionPoint:
+    """One decision during creation."""
+
+    slot_time: pd.Timestamp
+    role: str
+    available_staff: List[str]
+    chosen_staff: str
+    state_before: CreationState
+    decision_factors: Dict[str, float]
+    confidence: float
+
+
+class ShiftCreationProcessReconstructor:
+    """Reconstruct creation process from schedule data."""
+
+    def __init__(self) -> None:
+        self.decision_history: List[DecisionPoint] = []
+
+    # public API -----------------------------------------------------------
+    def reconstruct_creation_process(self, long_df: pd.DataFrame) -> Dict[str, Any]:
+        """Reconstruct process from a long dataframe."""
+        if long_df.empty:
+            return {}
+
+        df = long_df[long_df.get("parsed_slots_count", 0) > 0].sort_values(["ds", "role", "staff"])
+
+        current_state = CreationState(timestamp=df["ds"].min())
+        all_staff = sorted(df["staff"].unique())
+
+        grouped = df.groupby(["ds", "role"])
+        for (slot_time, role), group in grouped:
+            assigned = group["staff"].tolist()
+            available = self._estimate_available_staff(slot_time, all_staff, current_state)
+            for staff in assigned:
+                factors = self._analyze_decision_factors(staff, slot_time, current_state, available)
+                conf = self._calculate_decision_confidence(available, factors)
+                decision = DecisionPoint(
+                    slot_time=slot_time,
+                    role=role,
+                    available_staff=available,
+                    chosen_staff=staff,
+                    state_before=current_state.copy(),
+                    decision_factors=factors,
+                    confidence=conf,
+                )
+                self.decision_history.append(decision)
+                current_state = self._update_state(current_state, staff, slot_time, role)
+
+        return {
+            "decision_count": len(self.decision_history),
+            "timeline": self._create_timeline_summary(),
+        }
+
+    # internal helpers -----------------------------------------------------
+    def _estimate_available_staff(
+        self, slot_time: pd.Timestamp, all_staff: List[str], state: CreationState
+    ) -> List[str]:
+        available = []
+        for staff in all_staff:
+            if slot_time in state.assigned_slots.get(staff, []):
+                continue
+            daily_hours = self._get_daily_hours(staff, slot_time.date(), state)
+            if daily_hours >= 8:
+                continue
+            consecutive = state.consecutive_days.get(staff, 0)
+            if consecutive >= 5 and state.last_work_date.get(staff) == slot_time.date() - pd.Timedelta(days=1):
+                continue
+            available.append(staff)
+        return available
+
+    def _analyze_decision_factors(
+        self,
+        staff: str,
+        slot_time: pd.Timestamp,
+        state: CreationState,
+        available_staff: List[str],
+    ) -> Dict[str, float]:
+        avg_hours = np.mean([state.staff_hours.get(s, 0) for s in available_staff]) if available_staff else 0
+        fairness = 1.0 - abs(state.staff_hours.get(staff, 0) - avg_hours) / (avg_hours + 1)
+        prev_slot = slot_time - pd.Timedelta(minutes=30)
+        cont = 0.8 if prev_slot in state.assigned_slots.get(staff, []) else 0.2
+        return {
+            "fairness_score": fairness,
+            "continuity_score": cont,
+        }
+
+    def _calculate_decision_confidence(self, available_staff: List[str], factors: Dict[str, float]) -> float:
+        if len(available_staff) <= 1:
+            return 1.0
+        return float(np.mean(list(factors.values())))
+
+    def _update_state(
+        self, state: CreationState, staff: str, slot_time: pd.Timestamp, role: str
+    ) -> CreationState:
+        new_state = state.copy()
+        new_state.assigned_slots.setdefault(staff, []).append(slot_time)
+        new_state.staff_hours[staff] = new_state.staff_hours.get(staff, 0) + 0.5
+        date = slot_time.date()
+        last_date = new_state.last_work_date.get(staff)
+        if last_date and (date - last_date).days == 1:
+            new_state.consecutive_days[staff] = new_state.consecutive_days.get(staff, 0) + 1
+        else:
+            new_state.consecutive_days[staff] = 1
+        new_state.last_work_date[staff] = date
+        new_state.role_coverage[(slot_time, role)] = new_state.role_coverage.get((slot_time, role), 0) + 1
+        new_state.timestamp = slot_time
+        return new_state
+
+    def _get_daily_hours(self, staff: str, date: dt.date, state: CreationState) -> float:
+        slots = [s for s in state.assigned_slots.get(staff, []) if s.date() == date]
+        return len(slots) * 0.5
+
+    def _create_timeline_summary(self) -> List[Dict[str, Any]]:
+        timeline: Dict[pd.Timestamp, List[DecisionPoint]] = {}
+        for d in self.decision_history:
+            hour = d.slot_time.floor("H")
+            timeline.setdefault(hour, []).append(d)
+        summary = []
+        for hour, items in sorted(timeline.items()):
+            summary.append(
+                {
+                    "timestamp": hour.strftime("%Y-%m-%d %H:%M"),
+                    "decision_count": len(items),
+                    "staff_involved": len({i.chosen_staff for i in items}),
+                }
+            )
+        return summary
+
+
+class ImplicitRuleDiscoverer:
+    """Simple discovery of implicit rules from history."""
+
+    def discover_implicit_rules(
+        self, long_df: pd.DataFrame, decisions: List[DecisionPoint]
+    ) -> Dict[str, Any]:
+        if long_df.empty or not decisions:
+            return {}
+        weekday_pref: Dict[int, Dict[str, int]] = {}
+        for d in decisions:
+            wd = d.slot_time.dayofweek
+            weekday_pref.setdefault(wd, {})[d.chosen_staff] = weekday_pref.get(wd, {}).get(d.chosen_staff, 0) + 1
+        rules = []
+        for wd, counts in weekday_pref.items():
+            total = sum(counts.values())
+            for staff, cnt in counts.items():
+                if total > 0 and cnt / total > 0.5:
+                    rules.append({"weekday": wd, "staff": staff, "ratio": cnt / total})
+        return {"weekday_preferences": rules}


### PR DESCRIPTION
## Summary
- implement shift creation process reconstructor
- add advanced implicit knowledge engine
- basic Dash callbacks for enhanced blueprint analysis
- expose new utilities via task package

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas and shift_suite)*

------
https://chatgpt.com/codex/tasks/task_e_686392fca4e483338f6c13d22553d693