### PR TITLE
Add progress updates during advanced analysis

### DIFF
--- a/shift_suite/tasks/advanced_implicit_knowledge_engine.py
+++ b/shift_suite/tasks/advanced_implicit_knowledge_engine.py
@@ -5,7 +5,7 @@ import itertools
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Callable
 
 import networkx as nx
 import pandas as pd
@@ -32,7 +32,11 @@ class AdvancedImplicitKnowledgeEngine:
         self.discovered_knowledge: List[ImplicitKnowledge] = []
 
     # ------------------------------------------------------------------
-    def discover_all_implicit_knowledge(self, long_df: pd.DataFrame) -> Dict[str, Any]:
+    def discover_all_implicit_knowledge(
+        self,
+        long_df: pd.DataFrame,
+        progress_callback: Optional[Callable] = None,
+    ) -> Dict[str, Any]:
         """Run all discovery steps and return aggregated result."""
         if long_df.empty:
             return {
@@ -43,10 +47,24 @@ class AdvancedImplicitKnowledgeEngine:
                 "summary": "No implicit knowledge discovered.",
             }
 
+        if progress_callback:
+            progress_callback((55, "時間的パターンを分析中..."))
         temporal_knowledge = self._discover_temporal_patterns(long_df)
+
+        if progress_callback:
+            progress_callback((65, "社会的ダイナミクスを分析中..."))
         social_knowledge = self._discover_social_dynamics(long_df)
+
+        if progress_callback:
+            progress_callback((75, "最適化戦略を分析中..."))
         optimization_knowledge = self._discover_optimization_strategies(long_df)
+
+        if progress_callback:
+            progress_callback((85, "例外処理パターンを分析中..."))
         exception_knowledge = self._discover_exception_handling(long_df)
+
+        if progress_callback:
+            progress_callback((95, "継続的改善パターンを分析中..."))
         learning_knowledge = self._discover_learning_patterns(long_df)
 
         all_knowledge = (

--- a/shift_suite/tasks/enhanced_blueprint_callbacks.py
+++ b/shift_suite/tasks/enhanced_blueprint_callbacks.py
@@ -43,7 +43,10 @@ def register_enhanced_callbacks(app) -> None:
         # heavy advanced analysis
         set_progress((50, "高度な暗黙知を発見中..."))
         engine = AdvancedImplicitKnowledgeEngine()
-        advanced_results = engine.discover_all_implicit_knowledge(long_df)
+        advanced_results = engine.discover_all_implicit_knowledge(
+            long_df,
+            progress_callback=set_progress,
+        )
         advanced_display = create_advanced_analysis_display(advanced_results)
 
         set_progress((100, "分析完了！"))


### PR DESCRIPTION
## Summary
- pass a progress callback down to `AdvancedImplicitKnowledgeEngine`
- report progress at each analysis stage
- use the progress callback from Dash when running the engine

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68639f79838c8333a72edd846f78f171