### PR TITLE
Fix rules table serialization

### DIFF
--- a/dash_app.py
+++ b/dash_app.py
@@ -2198,7 +2198,18 @@ def update_blueprint_analysis_content(n_clicks):
     fig_scatter = px.scatter(scatter_df, x='fairness_score', y='cost_score', hover_data=['date']) if not scatter_df.empty else go.Figure()
 
     rules_df = blueprint_data.get('rules_df', pd.DataFrame())
-    rules_table_data = rules_df.to_dict('records') if not rules_df.empty else []
+
+    # テーブル用のデータを整形
+    if not rules_df.empty:
+        if '詳細データ' in rules_df.columns:
+            rules_df['詳細データ'] = rules_df['詳細データ'].apply(
+                lambda x: json.dumps(x, ensure_ascii=False, indent=2)
+                if isinstance(x, dict)
+                else str(x)
+            )
+        rules_table_data = rules_df.to_dict('records')
+    else:
+        rules_table_data = []
 
     store_data = {
         'rules_df': rules_df.to_json(orient='split') if not rules_df.empty else None,


### PR DESCRIPTION
## Summary
- sanitize detailed rule info before passing to DataTable

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for pandas and other deps)*

------
https://chatgpt.com/codex/tasks/task_e_6864aa9488d48333936c8c7a78b727b5