### PR TITLE
Fix duplicates in facts data table callbacks

### DIFF
--- a/dash_app.py
+++ b/dash_app.py
@@ -2271,7 +2271,7 @@ def update_team_analysis_graphs(selected_value, selected_key):
     Output('tradeoff-scatter-plot', 'figure'),
     Output('rules-data-table', 'data'),
     Output('staff-selector-dropdown', 'options'),
-    Output('facts-data-table', 'data'),
+    Output('facts-data-table', 'data', allow_duplicate=True),
     Output('facts-summary', 'children'),
     Output('integrated-analysis-content', 'children'),
     Input('generate-blueprint-button', 'n_clicks'),
@@ -2391,7 +2391,7 @@ def update_blueprint_analysis_content(n_clicks, analysis_type):
 
 
 @app.callback(
-    Output('facts-data-table', 'data'),
+    Output('facts-data-table', 'data', allow_duplicate=True),
     Input('fact-category-filter', 'value'),
     State('blueprint-results-store', 'data'),
     prevent_initial_call=True


### PR DESCRIPTION
## Summary
- allow updating `facts-data-table` outputs multiple times
- update associated callbacks in `dash_app.py`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6866155e43f48333bf88c563f835d8fe