### PR TITLE
Fix blueprint callback to prevent duplicate facts

### DIFF
--- a/dash_app.py
+++ b/dash_app.py
@@ -2276,6 +2276,7 @@ def update_team_analysis_graphs(selected_value, selected_key):
     Output('integrated-analysis-content', 'children'),
     Input('generate-blueprint-button', 'n_clicks'),
     State('blueprint-analysis-type', 'value'),
+    prevent_initial_call=True
 )
 def update_blueprint_analysis_content(n_clicks, analysis_type):
     if not n_clicks:


### PR DESCRIPTION
## Summary
- ensure `update_blueprint_analysis_content` callback does not run on page load by setting `prevent_initial_call=True`
- keep facts table output duplication for category filter callback

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6866164fb37883338858ece371c2f99a