### PR TITLE
Add error handling utilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,9 @@ pillow>=10.0      # ← 念のため追記を推奨
 python-pptx>=0.6
 ruff
 pytest
+# --- server / caching ---
+flask-caching>=2.0.0
+diskcache>=5.0.0
+psutil>=5.9.0
+gunicorn>=20.1.0
+gevent>=21.0.0


### PR DESCRIPTION
## Summary
- introduce Flask error handlers for JSON error responses
- provide a `safe_callback` decorator for robust callbacks
- use `safe_callback` on blueprint analysis callbacks
- list server dependencies in requirements

## Testing
- `ruff check .`
- `pytest -q` *(fails: 33 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_6866203967188333b9065623ba9282c5