### PR TITLE
Fix Sunday need calculation handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -1618,6 +1618,7 @@ if run_button_clicked:
                         long_df,
                         scenario_out_dir,
                         param_slot,
+                        include_zero_days=True,
                         need_calc_method=param_need_calc_method,
                         ref_start_date_for_need=param_need_ref_start,
                         ref_end_date_for_need=param_need_ref_end,
@@ -1653,6 +1654,7 @@ if run_button_clicked:
                         param_slot,
                         holidays=(holiday_dates_global_for_run or [])
                         + (holiday_dates_local_for_run or []),
+                        include_zero_days=True,
                         wage_direct=param_wage_direct,
                         wage_temp=param_wage_temp,
                         penalty_per_lack=param_penalty_lack,

--- a/cli.py
+++ b/cli.py
@@ -92,6 +92,7 @@ def main():
         long,
         out,
         args.slot,
+        include_zero_days=True,
         ref_start_date_for_need=ref_start,
         ref_end_date_for_need=ref_end,
         need_statistic_method="中央値",
@@ -105,6 +106,7 @@ def main():
         out,
         args.slot,
         holidays=(holiday_dates_global or []) + (holiday_dates_local or []),
+        include_zero_days=True,
     )
     try:
         build_hire_plan_from_shortage(out, safety_factor=args.safety_factor)

--- a/shift_suite/tasks/config/need_config.py
+++ b/shift_suite/tasks/config/need_config.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import List
+import datetime as dt
+
+
+@dataclass
+class NeedCalculationConfig:
+    """Need calculation settings."""
+
+    include_zero_days: bool = True
+    auto_holiday_detection: bool = False
+    statistic_method: str = "中央値"
+    remove_outliers: bool = True
+    iqr_multiplier: float = 1.5
+    adjustment_factor: float = 1.0
+    explicit_holidays: List[dt.date] | None = None
+    validation_enabled: bool = True
+    tolerance_factor: float = 3.0
+
+    def __post_init__(self) -> None:
+        if self.explicit_holidays is None:
+            self.explicit_holidays = []
+
+    def get_holidays_set(self) -> set[dt.date]:
+        return set(self.explicit_holidays)
+
+    def validate(self) -> List[str]:
+        errors: List[str] = []
+        if self.statistic_method not in ["中央値", "平均値", "25パーセンタイル"]:
+            errors.append("statistic_method must be one of 中央値, 平均値, 25パーセンタイル")
+        if self.tolerance_factor <= 0:
+            errors.append("tolerance_factor must be positive")
+        if self.adjustment_factor <= 0:
+            errors.append("adjustment_factor must be positive")
+        return errors


### PR DESCRIPTION
## Summary
- allow including zero-actual days in `calculate_pattern_based_need`
- pass `include_zero_days` option through `build_heatmap`
- support the option in CLI and Streamlit app
- adjust `shortage_and_brief` to use the same flag
- add validation helpers and config dataclass

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68664237297883338f7565d060ca8bfe