### PR TITLE
Fix midnight slot expansion

### DIFF
--- a/create_midnight_test_excel.py
+++ b/create_midnight_test_excel.py
@@ -26,4 +26,4 @@ def create_test_excel():
 
 if __name__ == "__main__":
     create_test_excel()
-    print(f"Created 'test_midnight_edge_cases.xlsx'")
+    print("Created 'test_midnight_edge_cases.xlsx'")

--- a/shift_suite/tasks/io_excel.py
+++ b/shift_suite/tasks/io_excel.py
@@ -100,6 +100,7 @@ def _to_hhmm(v: Any) -> str | None:
             log.debug(f"Excelシリアル値からの時刻変換エラー: 値='{v}', エラー='{e}'")
             return None
     s = str(v).strip()
+    # Excel may express midnight as "24:00"; convert to standard "00:00"
     if s == "24:00":
         return "00:00"
     if re.fullmatch(r"\d{1,2}:\d{2}:\d{2}", s):
@@ -124,9 +125,7 @@ def _expand(
         e_time = dt.datetime.strptime(ed, "%H:%M")
     except (ValueError, TypeError):
         return []
-    if ed == "00:00":
-        e_time = e_time.replace(hour=23, minute=59, second=59)
-    elif e_time <= s_time:
+    if ed == "00:00" or e_time <= s_time:
         e_time += dt.timedelta(days=1)
 
     slots: list[str] = []


### PR DESCRIPTION
## Summary
- treat midnight shift boundaries correctly in `_expand`
- clarify `'24:00'` handling in `_to_hhmm`
- clean up f-string in example test Excel script

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_686b8270e9308333a93b39a84740d015