### PR TITLE
Add detailed ingestion & need logs

### DIFF
--- a/shift_suite/tasks/heatmap.py
+++ b/shift_suite/tasks/heatmap.py
@@ -274,6 +274,9 @@ def calculate_pattern_based_need(
                 values_at_slot_current = [0.0 if pd.isna(v) else float(v) for v in row_series_data]
             else:
                 values_at_slot_current = row_series_data.dropna().astype(float).tolist()
+            analysis_logger.info(
+                f"[DEBUG_NEED_DETAIL] 処理中の時間帯: {time_slot_val} ({dow_name}), 元データ ({len(values_at_slot_current)}点): {values_at_slot_current}"
+            )
 
             if not values_at_slot_current:
                 dow_need_df_calculated.loc[time_slot_val, day_of_week_idx] = 0
@@ -303,6 +306,10 @@ def calculate_pattern_based_need(
                 if day_of_week_idx == 6 and time_slot_val in ["09:00", "12:00", "15:00"]:
                     log.info(f"[SUNDAY_DETAIL]   外れ値除去後: {values_filtered_outlier}")
 
+                analysis_logger.info(
+                    f"[DEBUG_NEED_DETAIL] 外れ値除去実行前 (Q1:{q1_val:.1f}, Q3:{q3_val:.1f}, IQR:{iqr_val:.1f}), フィルタリング後 ({len(values_filtered_outlier)}点): {values_filtered_outlier}"
+                )
+
                 if not values_filtered_outlier:
                     log.debug(
                         f"  曜日 {day_of_week_idx}, 時間帯 {time_slot_val}: 外れ値除去後データなし。元のリストで計算します。"
@@ -324,6 +331,9 @@ def calculate_pattern_based_need(
                     need_calculated_val = np.percentile(values_for_stat_calc, 90)
                 else:  # 平均値
                     need_calculated_val = np.mean(values_for_stat_calc)
+            analysis_logger.info(
+                f"[DEBUG_NEED_DETAIL] 統計手法({current_statistic_method})適用後のNeed仮値: {need_calculated_val:.2f}"
+            )
 
             # データの中央値が小さい場合はNeedを上限2.0に制限
             if values_at_slot_current and np.median(values_at_slot_current) < 2.0:
@@ -331,6 +341,9 @@ def calculate_pattern_based_need(
                 analysis_logger.info(
                     f"  [NEED_CAP] 曜日 {day_of_week_idx}, 時間帯 {time_slot_val}: "
                     f"実績中央値が2未満のためNeedを {need_calculated_val:.1f} に制限しました。"
+                )
+                analysis_logger.info(
+                    f"[DEBUG_NEED_DETAIL] Need上限適用判定: 元データ中央値={np.median(values_at_slot_current):.1f}。制限後Need={need_calculated_val:.2f}"
                 )
 
             # 調整係数の適用

--- a/shift_suite/tasks/io_excel.py
+++ b/shift_suite/tasks/io_excel.py
@@ -119,6 +119,9 @@ def _expand(
     st: str | None, ed: str | None, slot_minutes: int = SLOT_MINUTES
 ) -> list[str]:
     """Expand start and end time into time slots spaced by ``slot_minutes``."""
+    analysis_logger.info(
+        f"[DEBUG_EXPAND] _expand呼び出し: st='{st}', ed='{ed}', slot_minutes={slot_minutes}"
+    )
     if not st or not ed:
         return []
     try:
@@ -130,12 +133,18 @@ def _expand(
     if ed == "00:00" or (e_time <= s_time and st != ed):
         e_time += dt.timedelta(days=1)
         is_overnight = True
+        analysis_logger.info(
+            f"[DEBUG_EXPAND] 翌日跨ぎシフトを検出: e_timeが1日進められました -> '{e_time.strftime('%H:%M')}'"
+        )
 
     slots: list[str] = []
     current_time = s_time
     max_slots = (24 * 60) // slot_minutes + 1
 
     while (current_time < e_time or (current_time == e_time and e_time.time() == dt.time(0, 0))) and len(slots) < max_slots:
+        analysis_logger.info(
+            f"[DEBUG_EXPAND] スロット追加: {current_time.strftime('%H:%M')}. 現在時刻 < 終了時刻: {current_time < e_time}, 終了時刻が0:00: {e_time.time() == dt.time(0,0)}, 追加継続条件: {(current_time < e_time or (current_time == e_time and e_time.time() == dt.time(0, 0)))}"
+        )
         slots.append(current_time.strftime("%H:%M"))
         current_time += dt.timedelta(minutes=slot_minutes)
 
@@ -151,6 +160,9 @@ def _expand(
             f"生成されたスロット数: {len(slots)}, "
             f"スロットリスト: {slots}"
         )
+    analysis_logger.info(
+        f"[DEBUG_EXPAND] スロット展開完了: 生成スロット数={len(slots)}. リスト: {slots}"
+    )
     return slots
 
 
@@ -470,11 +482,18 @@ def ingest_excel(
                             f"シート '{sheet_name_actual}' の日付列パースに失敗しました: 元の列名='{c}'"
                         )
 
+        analysis_logger.info(
+            f"[DEBUG_INGEST] 認識された日付列ヘッダーとそのパース結果: {sorted([(k, v.strftime('%Y-%m-%d')) for k,v in date_col_map.items()])}"
+        )
+
         log.debug(f"日付列マッピング結果: {len(date_col_map)}個成功")
         for col, date in date_col_map.items():
             log.debug(f"  {col} → {date}")
 
         all_dates_from_headers.update(date_col_map.values())
+        analysis_logger.info(
+            f"[DEBUG_INGEST] 全てのシートヘッダーから抽出された日付のリスト: {sorted([d.strftime('%Y-%m-%d') for d in all_dates_from_headers])}"
+        )
 
         for _, row_data in df_sheet.iterrows():
             staff = _normalize(row_data.get("staff", ""))
@@ -611,6 +630,9 @@ def ingest_excel(
                     "parsed_slots_count": 0,
                 }
             )
+            analysis_logger.info(
+                f"[DEBUG_INGEST] 欠落日付のためのプレースホルダーレコードを追加: {d.strftime('%Y-%m-%d')}"
+            )
 
     if unknown_codes:
         log.warning(
@@ -628,6 +650,12 @@ def ingest_excel(
     if not final_long_df.empty:
         final_long_df["ds"] = pd.to_datetime(final_long_df["ds"])
         final_long_df = final_long_df.sort_values("ds").reset_index(drop=True)
+        analysis_logger.info(
+            f"[DEBUG_INGEST] 最終的なlong_dfの日付範囲: {final_long_df['ds'].dt.date.min().strftime('%Y-%m-%d')} から {final_long_df['ds'].dt.date.max().strftime('%Y-%m-%d')}"
+        )
+        analysis_logger.info(
+            f"[DEBUG_INGEST] 最終long_dfに含まれるユニークな日付数: {final_long_df['ds'].dt.date.nunique()}"
+        )
 
     # 処理結果の統計をログ出力
     if not final_long_df.empty:


### PR DESCRIPTION
## Summary
- add debug logging for date column handling and final dataframe stats
- include slot expansion details in `_expand`
- log per-slot Need calculation details

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686e272932308333aa3ead2e68859d31