### PR TITLE
Fix shortage_time path

### DIFF
--- a/dash_app.py
+++ b/dash_app.py
@@ -207,6 +207,7 @@ def data_get(key: str, default=None):
     special = {
         "long_df": ["intermediate_data.parquet"],
         "daily_cost": ["daily_cost.parquet", "daily_cost.xlsx"],
+        "shortage_time": ["shortage_time_CORRECTED.parquet"],
     }
 
     filenames = special.get(key, [f"{key}.parquet", f"{key}.csv", f"{key}.xlsx"])


### PR DESCRIPTION
## Summary
- update the filename used for `shortage_time` parquet files

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686fab82134883338dea3957f1019b69